### PR TITLE
Bump cibuildwheel to 2.19.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.10' 
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.19.1 pytest apsw numpy
+        run: python -m pip install cibuildwheel==2.19.2 pytest apsw numpy
 
       - uses: ilammy/msvc-dev-cmd@v1 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,4 @@ environment = {MACOSX_DEPLOYMENT_TARGET = "10.15"} # 10.15 is the minimum versio
 
 # todo: support musllinux
 [tool.cibuildwheel.linux]
-# https://github.com/pypa/cibuildwheel/issues/1915 and https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
-before-build = "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*; sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*;yum install -y ninja-build"
+before-build = "yum install -y ninja-build"


### PR DESCRIPTION
Bump cibuildwheel to 2.19.2 since https://github.com/pypa/cibuildwheel/issues/1915 is fixed.