### PR TITLE
Avoid copy by using VectorView and update benchmark.py for sqlite-vec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
     set(OPTION_USE_AVX ON)
 endif ()
 
-add_library(vectorlite SHARED src/vectorlite.cpp src/virtual_table.cpp src/vector.cpp src/util.cpp src/vector_space.cpp src/index_options.cpp src/sqlite_functions.cpp src/constraint.cpp)
+add_library(vectorlite SHARED src/vectorlite.cpp src/virtual_table.cpp src/vector.cpp src/vector_view.cpp src/util.cpp src/vector_space.cpp src/index_options.cpp src/sqlite_functions.cpp src/constraint.cpp)
 # remove the lib prefix to make the shared library name consistent on all platforms.
 set_target_properties(vectorlite PROPERTIES PREFIX "")
 target_include_directories(vectorlite PUBLIC ${RAPIDJSON_INCLUDE_DIRS} ${HNSWLIB_INCLUDE_DIRS} ${PROJECT_BINARY_DIR})

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -33,7 +33,7 @@ conn.load_extension('build/release/vectorlite')  # loads vectorlite
 
 cursor = conn.cursor()
 
-NUM_ELEMENTS = 10000  # number of vectors
+NUM_ELEMENTS = 1000  # number of vectors
 NUM_QUERIES = 100  # number of queries
 
 DIMS = [256, 1024]

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,5 +1,5 @@
 import time
-from typing import Literal
+from typing import Literal, Optional
 import numpy as np
 import vectorlite_py
 import apsw
@@ -15,12 +15,10 @@ Benchamrk vectorlite's performance and recall rate using method described in htt
 """
 
 
-
-
 # Roll our own timeit function to measure time in us and get return value of the func.
 # Why Python's built-in timeit.timeit is not used:
 # 1. it includes unnecessary overheads, because compiles the code passed to it
-# 2. func's return value is cannot be obtained directly
+# 2. func's return value cannot be obtained directly
 def timeit(func):
     start_us = time.perf_counter_ns() / 1000
     retval = func()
@@ -34,7 +32,7 @@ conn.load_extension(vectorlite_py.vectorlite_path())  # loads vectorlite
 
 cursor = conn.cursor()
 
-NUM_ELEMENTS = 1000  # number of vectors
+NUM_ELEMENTS = 2000  # number of vectors
 NUM_QUERIES = 100  # number of queries
 
 DIMS = [256, 1024]
@@ -46,7 +44,7 @@ query_data = {dim: np.float32(np.random.random((NUM_QUERIES, dim))) for dim in D
 k = 10
 
 # (ef_construction, M)
-hnsw_params = [(200, 32), (200, 48), (200, 64)]
+hnsw_params = [(200, 64)]
 
 # ef_search
 efs = [10, 50, 100, 150]
@@ -172,46 +170,105 @@ result_table = ResultTable(benchmark_results)
 console.print(result_table)
 
 
+@dataclasses.dataclass
+class BruteForceBenchmarkResult:
+    dim: int
+    insert_time_us: float  # in micro seconds, per vector
+    search_time_us: float  # in micro seconds, per query
+    recall_rate: float  # in micro seconds
+
+
+@dataclasses.dataclass
+class BruteForceResultTable:
+    results: list[BruteForceBenchmarkResult]
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        table = Table()
+        table.add_column("vector dimension")
+        table.add_column("insert_time(per vector)")
+        table.add_column("search_time(per query)")
+        table.add_column("recall_rate")
+        for result in self.results:
+            table.add_row(
+                str(result.dim),
+                f"{result.insert_time_us:.2f} us",
+                f"{result.search_time_us:.2f} us",
+                f"{result.recall_rate * 100:.2f}%",
+            )
+        yield table
+
+
+brute_force_benchmark_results = []
+
+
+def benchmark_brute_force(dim: int):
+    benchmark_result = BruteForceBenchmarkResult(dim, 0, 0, 0)
+    table_name = f"table_vectorlite_bf_{dim}"
+    cursor.execute(
+        f"create table {table_name}(rowid integer primary key, embedding blob)"
+    )
+
+    insert_time_us, _ = timeit(
+        lambda: cursor.executemany(
+            f"insert into {table_name}(rowid, embedding) values (?, ?)",
+            [(i, data[dim][i].tobytes()) for i in range(NUM_ELEMENTS)],
+        )
+    )
+    benchmark_result.insert_time_us = insert_time_us / NUM_ELEMENTS
+
+    def my_tracer(cursor: apsw.Cursor, statement: str, bindings) -> bool:
+        print("SQL:", statement.strip())
+        print("Bindings:", bindings)
+        return True  # if you return False then execution is aborted
+
+    cursor.exec_trace = my_tracer
+    def search():
+        result = []
+        for i in range(NUM_QUERIES):
+            # console.log(cursor.execute(f"select typeof(?)", (query_data[dim][i].tobytes(),)).fetchone())
+            # console.log(type(query_data[dim][i]))
+            console.log(cursor.execute(f"select vector_distance(?, ?, 'l2')", (query_data[dim][i].tobytes(), query_data[dim][i].tobytes())).fetchone())
+            result.append(
+                cursor.execute(
+                    f"select rowid, vector_distance(?, embedding, 'l2') as distance from {table_name} order by distance desc limit {k}",
+                    [query_data[dim][i].tobytes()],
+                ).fetchall()
+            )
+        return [r[0] for r in result]
+
+    search_time_us, results = timeit(search)
+    benchmark_result.search_time_us = search_time_us / NUM_QUERIES
+    recall_rate = np.mean(
+        np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
+        for i in range(NUM_QUERIES)
+    )
+    benchmark_result.recall_rate = recall_rate
+    brute_force_benchmark_results.append(benchmark_result)
+for dim in DIMS:
+    benchmark_brute_force(dim)
+brute_force_table = BruteForceResultTable(brute_force_benchmark_results)
+console.print(brute_force_table)
+
+
+# Benchmark sqlite_vss as compariso.
+# pip install sqlite-vss
 import platform
-benchmark_vss = os.environ.get('BENCHMARK_VSS', '0') != '0'
+
+benchmark_vss = os.environ.get("BENCHMARK_VSS", "0") != "0"
 if benchmark_vss and platform.system().lower() == "linux":
     # note sqlite_vss is not self-contained.
     # Need to install dependencies manually using: sudo apt-get install -y libgomp1 libatlas-base-dev liblapack-dev
     console.print("Bencharmk sqlite_vss as comparison.")
     import sqlite_vss
+
     sqlite_vss.load(conn)
 
-    @dataclasses.dataclass
-    class VssBenchmarkResult:
-        dim: int
-        insert_time_us: float  # in micro seconds, per vector
-        search_time_us: float  # in micro seconds, per query
-        recall_rate: float  # in micro seconds
-
-    @dataclasses.dataclass
-    class VssResultTable:
-        results: list[VssBenchmarkResult]
-
-        def __rich_console__(
-            self, console: Console, options: ConsoleOptions
-        ) -> RenderResult:
-            table = Table()
-            table.add_column("vector dimension")
-            table.add_column("insert_time(per vector)")
-            table.add_column("search_time(per query)")
-            table.add_column("recall_rate")
-            for result in self.results:
-                table.add_row(
-                    str(result.dim),
-                    f"{result.insert_time_us:.2f} us",
-                    f"{result.search_time_us:.2f} us",
-                    f"{result.recall_rate * 100:.2f}%",
-                )
-            yield table
-
     vss_benchmark_results = []
+
     def benchmark_sqlite_vss(dim: int):
-        benchmark_result = VssBenchmarkResult(dim, 0, 0, 0)
+        benchmark_result = BruteForceBenchmarkResult(dim, 0, 0, 0)
         table_name = f"table_vss_{dim}"
         cursor.execute(
             f"create virtual table {table_name} using vss0(embedding({dim}))"
@@ -236,13 +293,12 @@ if benchmark_vss and platform.system().lower() == "linux":
                     ).fetchall()
                 )
             return result
-        
+
         search_time_us, results = timeit(search)
         benchmark_result.search_time_us = search_time_us / NUM_QUERIES
         recall_rate = np.mean(
             [
-                np.intersect1d(results[i], correct_labels["cosine"][dim][i]).size
-                / k
+                np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
                 for i in range(NUM_QUERIES)
             ]
         )
@@ -252,5 +308,60 @@ if benchmark_vss and platform.system().lower() == "linux":
     for dim in DIMS:
         benchmark_sqlite_vss(dim)
 
-    vss_result_table = VssResultTable(vss_benchmark_results)
+    vss_result_table = BruteForceResultTable(vss_benchmark_results)
     console.print(vss_result_table)
+
+# benchmark sqlite-vec
+# pip install sqlite-vec
+benchmark_sqlite_vec = os.environ.get("BENCHMARK_SQLITE_VEC", "0") != "0"
+if benchmark_sqlite_vec and platform.system().lower() == "linux":
+    # VssBenchamrkResult and VssResultTable can be reused
+    vec_benchmark_results = []
+    console.print("Bencharmk sqlite_vec as comparison.")
+    import sqlite_vec
+
+    conn.load_extension(sqlite_vec.loadable_path())
+
+    def benchmark_sqlite_vec(dim: int):
+        benchmark_result = BruteForceBenchmarkResult(dim, 0, 0, 0)
+        table_name = f"table_vec_{dim}"
+        cursor.execute(
+            f"create virtual table {table_name} using vec0(rowid integer primary key, embedding float[{dim}])"
+        )
+
+        # measure insert time
+        insert_time_us, _ = timeit(
+            lambda: cursor.executemany(
+                f"insert into {table_name}(rowid, embedding) values (?, ?)",
+                [(i, data[dim][i].tobytes()) for i in range(NUM_ELEMENTS)],
+            )
+        )
+        benchmark_result.insert_time_us = insert_time_us / NUM_ELEMENTS
+
+        def search():
+            result = []
+            for i in range(NUM_QUERIES):
+                result.append(
+                    cursor.execute(
+                        f"select rowid from {table_name} where embedding match ? and k = {k}",
+                        (query_data[dim][i].tobytes(),),
+                    ).fetchall()
+                )
+            return result
+
+        search_time_us, results = timeit(search)
+        benchmark_result.search_time_us = search_time_us / NUM_QUERIES
+        recall_rate = np.mean(
+            [
+                np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
+                for i in range(NUM_QUERIES)
+            ]
+        )
+        benchmark_result.recall_rate = recall_rate
+        vec_benchmark_results.append(benchmark_result)
+
+    for dim in DIMS:
+        benchmark_sqlite_vec(dim)
+
+    vec_result_table = BruteForceResultTable(vec_benchmark_results)
+    console.print(vec_result_table)

--- a/bindings/nodejs/packages/vectorlite/test/test.js
+++ b/bindings/nodejs/packages/vectorlite/test/test.js
@@ -2,7 +2,7 @@ const sqlite3 = require('better-sqlite3');
 const vectorlite = require('../src/index.js');
 
 const db = new sqlite3(':memory:');
-db.loadExtension(vectorlite.vectorlitePath());
+db.loadExtension('/home/yefu/sqlite-hnsw/build/dev/vectorlite.so');
 
 console.log(db.prepare('select vectorlite_info()').all());
 
@@ -22,6 +22,12 @@ console.log(result);
 
 // a vector query with rowid filter
 result = db.prepare('select rowid from test where knn_search(vec, knn_param(?, 2)) and rowid in (1,2,3)')
+    .all([Buffer.from(Float32Array.from(Array.from({length: 10}, () => Math.random())).buffer)]);
+
+console.log(result);
+
+// a vector query with rowid filter
+result = db.prepare('select rowid, vector_distance(vec, ?, \'l2\') from test where rowid in (0,1,2,3)')
     .all([Buffer.from(Float32Array.from(Array.from({length: 10}, () => Math.random())).buffer)]);
 
 console.log(result);

--- a/bindings/nodejs/packages/vectorlite/test/test.js
+++ b/bindings/nodejs/packages/vectorlite/test/test.js
@@ -2,7 +2,7 @@ const sqlite3 = require('better-sqlite3');
 const vectorlite = require('../src/index.js');
 
 const db = new sqlite3(':memory:');
-db.loadExtension('/home/yefu/sqlite-hnsw/build/dev/vectorlite.so');
+db.loadExtension(vectorlite.vectorlitePath());
 
 console.log(db.prepare('select vectorlite_info()').all());
 

--- a/src/sqlite_functions.cpp
+++ b/src/sqlite_functions.cpp
@@ -36,10 +36,19 @@ void VectorDistance(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
     return;
   }
 
-  if (sqlite3_value_type(argv[0]) != SQLITE_BLOB ||
-      sqlite3_value_type(argv[1]) != SQLITE_BLOB) {
-    sqlite3_result_error(ctx, "vectors_distance expects vectors of type blob",
-                         -1);
+  auto type1 = sqlite3_value_type(argv[0]);
+  auto type2 = sqlite3_value_type(argv[1]);
+  if (type1 != SQLITE_BLOB || type2 != SQLITE_BLOB) {
+    DLOG_IF(INFO, type1 != SQLITE_BLOB && type1 == SQLITE_TEXT)
+        << "vector1 is of type TEXT" << sqlite3_value_text(argv[0])
+        << " with size " << sqlite3_value_bytes(argv[0]);
+    DLOG_IF(INFO, type2 != SQLITE_BLOB && type2 == SQLITE_TEXT)
+        << "vector2 is of type TEXT" << sqlite3_value_text(argv[1])
+        << " with size " << sqlite3_value_bytes(argv[1]);
+    std::string err = absl::StrFormat(
+        "vector_distance expects vectors of type blob but found %u and %u",
+        type1, type2);
+    sqlite3_result_error(ctx, err.c_str(), -1);
     return;
   }
 

--- a/src/sqlite_functions.cpp
+++ b/src/sqlite_functions.cpp
@@ -73,7 +73,7 @@ void VectorDistance(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
       reinterpret_cast<const char *>(sqlite3_value_blob(argv[0])),
       sqlite3_value_bytes(argv[0]));
 
-  auto v1 = vectorlite::Vector::FromBlob(v1_str);
+  auto v1 = vectorlite::VectorView::FromBlob(v1_str);
   if (!v1.ok()) {
     std::string err = absl::StrFormat("Failed to parse 1st vector due to: %s",
                                       v1.status().message());
@@ -84,7 +84,7 @@ void VectorDistance(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
   std::string_view v2_str(
       reinterpret_cast<const char *>(sqlite3_value_blob(argv[1])),
       sqlite3_value_bytes(argv[1]));
-  auto v2 = vectorlite::Vector::FromBlob(v2_str);
+  auto v2 = vectorlite::VectorView::FromBlob(v2_str);
   if (!v2.ok()) {
     std::string err = absl::StrFormat("Failed to parse 2nd vector due to: %s",
                                       v2.status().message());
@@ -148,17 +148,15 @@ void VectorToJson(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
       reinterpret_cast<const char *>(sqlite3_value_blob(argv[0])),
       sqlite3_value_bytes(argv[0]));
 
-  // todo: avoid copying by not constructing a new vector. Because we only need
-  // read-only access here.
-  auto vector = vectorlite::Vector::FromBlob(vector_blob);
-  if (!vector.ok()) {
+  auto vector_view = vectorlite::VectorView::FromBlob(vector_blob);
+  if (!vector_view.ok()) {
     std::string err = absl::StrFormat("Failed to parse vector due to: %s",
-                                      vector.status().message());
+                                      vector_view.status().message());
     sqlite3_result_error(ctx, err.c_str(), err.length());
     return;
   }
 
-  auto json = vector->ToJSON();
+  auto json = vector_view->ToJSON();
   sqlite3_result_text(ctx, json.data(), json.size(), SQLITE_TRANSIENT);
   return;
 }

--- a/src/sqlite_functions.cpp
+++ b/src/sqlite_functions.cpp
@@ -70,7 +70,7 @@ void VectorDistance(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
   }
 
   std::string_view v1_str(
-      reinterpret_cast<const char *>(sqlite3_value_text(argv[0])),
+      reinterpret_cast<const char *>(sqlite3_value_blob(argv[0])),
       sqlite3_value_bytes(argv[0]));
 
   auto v1 = vectorlite::Vector::FromBlob(v1_str);
@@ -82,7 +82,7 @@ void VectorDistance(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
   }
 
   std::string_view v2_str(
-      reinterpret_cast<const char *>(sqlite3_value_text(argv[1])),
+      reinterpret_cast<const char *>(sqlite3_value_blob(argv[1])),
       sqlite3_value_bytes(argv[1]));
   auto v2 = vectorlite::Vector::FromBlob(v2_str);
   if (!v2.ok()) {

--- a/src/vector.h
+++ b/src/vector.h
@@ -7,6 +7,7 @@
 #include "absl/status/statusor.h"
 #include "macros.h"
 #include "vector_space.h"
+#include "vector_view.h"
 
 namespace vectorlite {
 
@@ -18,6 +19,8 @@ class Vector {
 
   explicit Vector(std::vector<float>&& data) : data_(std::move(data)) {}
   explicit Vector(const std::vector<float>& data) : data_(data) {}
+  explicit Vector(VectorView vector_view)
+      : data_(vector_view.data().begin(), vector_view.data().end()) {}
 
   Vector& operator=(const Vector&) = default;
   Vector& operator=(Vector&&) = default;
@@ -36,12 +39,14 @@ class Vector {
 
   Vector Normalize() const;
 
+  static Vector Normalize(VectorView vector_view);
+
  private:
   std::vector<float> data_;
 };
 
 // Calculate the distance between two vectors.
-absl::StatusOr<float> Distance(const Vector& v1, const Vector& v2,
+absl::StatusOr<float> Distance(VectorView v1, VectorView v2,
                                DistanceType space);
 
 }  // namespace vectorlite

--- a/src/vector_view.cpp
+++ b/src/vector_view.cpp
@@ -1,0 +1,44 @@
+#include "vector_view.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rapidjson/document.h"
+#include "rapidjson/error/en.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+#include "vector.h"
+
+namespace vectorlite {
+
+VectorView::VectorView(const Vector& vector) : data_(vector.data()) {}
+
+absl::StatusOr<VectorView> VectorView::FromBlob(std::string_view blob) {
+  if (blob.size() % sizeof(float) != 0) {
+    return absl::InvalidArgumentError("Blob size is not a multiple of float");
+  }
+  return VectorView(absl::MakeSpan(reinterpret_cast<const float*>(blob.data()),
+                                   blob.size() / sizeof(float)));
+}
+
+std::string VectorView::ToJSON() const {
+  rapidjson::Document doc;
+  doc.SetArray();
+
+  auto& allocator = doc.GetAllocator();
+  for (float v : data_) {
+    doc.PushBack(v, allocator);
+  }
+
+  rapidjson::StringBuffer buf;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+  doc.Accept(writer);
+
+  return buf.GetString();
+}
+
+std::string_view VectorView::ToBlob() const {
+  return std::string_view(reinterpret_cast<const char*>(data_.data()),
+                          data_.size() * sizeof(float));
+}
+
+}  // namespace vectorlite

--- a/src/vector_view.h
+++ b/src/vector_view.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+
+namespace vectorlite {
+
+class Vector;
+
+// VectorView is a read-only view of a vector, like std::string_view is to
+// std::string.
+class VectorView {
+ public:
+  VectorView() = default;
+  VectorView(const VectorView&) = default;
+  VectorView(VectorView&&) = default;
+
+  VectorView(const Vector& vector);
+  explicit VectorView(absl::Span<const float> data) : data_(data) {}
+
+  VectorView& operator=(const VectorView&) = default;
+  VectorView& operator=(VectorView&&) = default;
+
+  static absl::StatusOr<VectorView> FromBlob(std::string_view blob);
+
+  std::string ToJSON() const;
+
+  std::string_view ToBlob() const;
+
+  std::size_t dim() const { return data_.size(); }
+
+  absl::Span<const float> data() const { return data_; }
+
+ private:
+  absl::Span<const float> data_;
+};
+
+}  // namespace vectorlite

--- a/src/vector_view_test.cpp
+++ b/src/vector_view_test.cpp
@@ -1,0 +1,37 @@
+#include "vector_view.h"
+
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "vector.h"
+#include "vector_space.h"
+
+TEST(VectorViewTest, Reversible_ToBinary_FromBinary) {
+  std::vector<float> data = {1.1, 2.23, 3.0};
+
+  std::string_view blob(reinterpret_cast<const char*>(data.data()),
+                        data.size() * sizeof(float));
+
+  auto v2 = vectorlite::VectorView::FromBlob(blob);
+  EXPECT_TRUE(v2.ok());
+  EXPECT_EQ(data.size(), v2->dim());
+  EXPECT_EQ(blob, v2->ToBlob());
+}
+
+TEST(VectorViewTest, FromBinaryShouldFailWithInvalidInput) {
+  auto v1 = vectorlite::VectorView::FromBlob(std::string_view("aaa"));
+  EXPECT_FALSE(v1.ok());
+}
+
+TEST(VectorViewTest, ToJSON) {
+  std::vector<float> data = {1.1, 2.23, 3.0};
+  vectorlite::VectorView v(data);
+
+  std::string json = v.ToJSON();
+  auto result = vectorlite::Vector::FromJSON(json);
+  EXPECT_TRUE(result.ok());
+
+  for (int i = 0; i < data.size(); i++) {
+    EXPECT_FLOAT_EQ(data[i], result->data()[i]);
+  }
+}

--- a/src/vectorlite.cpp
+++ b/src/vectorlite.cpp
@@ -51,7 +51,7 @@ VECTORLITE_EXPORT int sqlite3_extension_init(sqlite3 *db, char **pzErrMsg,
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
 
-  rc = sqlite3_create_function(db, "vector_distance", 3, SQLITE_UTF8, nullptr,
+  rc = sqlite3_create_function(db, "vector_distance", 3, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
                                vectorlite::VectorDistance, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf("Failed to create function vector_distance: %s",
@@ -59,7 +59,7 @@ VECTORLITE_EXPORT int sqlite3_extension_init(sqlite3 *db, char **pzErrMsg,
     return rc;
   }
 
-  rc = sqlite3_create_function(db, "vector_from_json", 1, SQLITE_UTF8, nullptr,
+  rc = sqlite3_create_function(db, "vector_from_json", 1, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
                                vectorlite::VectorFromJson, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf(
@@ -67,7 +67,7 @@ VECTORLITE_EXPORT int sqlite3_extension_init(sqlite3 *db, char **pzErrMsg,
     return rc;
   }
 
-  rc = sqlite3_create_function(db, "vector_to_json", 1, SQLITE_UTF8, nullptr,
+  rc = sqlite3_create_function(db, "vector_to_json", 1, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
                                vectorlite::VectorToJson, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf("Failed to create function vector_to_json: %s",

--- a/src/vectorlite.cpp
+++ b/src/vectorlite.cpp
@@ -51,24 +51,30 @@ VECTORLITE_EXPORT int sqlite3_extension_init(sqlite3 *db, char **pzErrMsg,
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
 
-  rc = sqlite3_create_function(db, "vector_distance", 3, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
-                               vectorlite::VectorDistance, nullptr, nullptr);
+  rc = sqlite3_create_function(
+      db, "vector_distance", 3,
+      SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
+      vectorlite::VectorDistance, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf("Failed to create function vector_distance: %s",
                                 sqlite3_errstr(rc));
     return rc;
   }
 
-  rc = sqlite3_create_function(db, "vector_from_json", 1, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
-                               vectorlite::VectorFromJson, nullptr, nullptr);
+  rc = sqlite3_create_function(
+      db, "vector_from_json", 1,
+      SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
+      vectorlite::VectorFromJson, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf(
         "Failed to create function vector_from_json: %s", sqlite3_errstr(rc));
     return rc;
   }
 
-  rc = sqlite3_create_function(db, "vector_to_json", 1, SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
-                               vectorlite::VectorToJson, nullptr, nullptr);
+  rc = sqlite3_create_function(
+      db, "vector_to_json", 1,
+      SQLITE_UTF8 | SQLITE_INNOCUOUS | SQLITE_DETERMINISTIC, nullptr,
+      vectorlite::VectorToJson, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     *pzErrMsg = sqlite3_mprintf("Failed to create function vector_to_json: %s",
                                 sqlite3_errstr(rc));


### PR DESCRIPTION
This PR does 3 things:
1. Introduce VectorView to avoid unnecessary copy of vectors
2. Register `vector_distance`, `vector_to_json`, `vector_from_json` as  `SQLITE_INNOCUOUS` and `SQLITE_DETERMINISTIC`  see https://sqlite.org/forum/forumpost/4a8b1f9d3b . So that brute force with vectorlite can be simply done by `select rowid from my_table order by vector_distance(some_vector, embedding, 'l2') asc limit 10`
3. Update benchmark.py for sqlite-vec

The benchmark data will be updated when I get access to my PC.