### PR TITLE
Add milvus lite benchmark

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -216,7 +216,7 @@ console.print(result_table)
 hnswlib_benchmark_results = []
 console.print("Bencharmk hnswlib as comparison.")
 def benchmark_hnswlib(distance_type, dim, ef_construction, M):
-    result = BenchmarkResult(distance_type, dim, ef_construction, M, 0, 0, 0, 0, "vectorLite")
+    result = BenchmarkResult(distance_type, dim, ef_construction, M, 0, 0, 0, 0, "hnswlib")
     hnswlib_index = hnswlib.Index(space=distance_type, dim=dim)
     hnswlib_index.init_index(max_elements=NUM_ELEMENTS, ef_construction=ef_construction, M=M)
 
@@ -267,7 +267,7 @@ brute_force_benchmark_results = []
 console.print("Bencharmk vectorlite brute force(select rowid from my_table order by vector_distance(query_vector, embedding, 'l2')) as comparison.")
 
 def benchmark_brute_force(dim: int):
-    benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
+    benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite_brute_force")
     table_name = f"table_vectorlite_bf_{dim}"
     cursor.execute(
         f"create table {table_name}(rowid integer primary key, embedding blob)"

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -125,6 +125,7 @@ class ResultTable:
                 )
             else:
                 table.add_row(
+                    result.product,
                     result.distance_type,
                     str(result.dim),
                     f"{result.insert_time_us:.2f} us",
@@ -138,7 +139,7 @@ class PlotData:
     time_taken_us: float
     column: str
 
-
+benchmark_milvus_results = []
 benchmark_results = []
 plot_data_for_insertion = defaultdict(list)
 plot_data_for_query = defaultdict(list)
@@ -204,112 +205,9 @@ def benchmark(distance_type, dim, ef_constructoin, M):
         benchmark_results.append(result)
         plot_data_for_query[dim].append(PlotData(result.search_time_us, f"vectorlite_{distance_type}_ef_{ef}"))
     cursor.execute(f"drop table {table_name}")
-    result_table = ResultTable(benchmark_results)
-    console.print(result_table)
-
-
-import os
-from pymilvus import MilvusClient
-from pymilvus import (
-    connections,
-    FieldSchema, CollectionSchema, DataType,
-    Collection,
-)
-# from pymilvus import model
-import numpy as np
-
-client = MilvusClient("./milvus_demo6.db")
-
-def milvus_insert(client, collection_name, data):
-    client.insert(collection_name=collection_name, data=data)
-
-def milvus_insert_many(client, collection_name, dim):
-    insert_data = [{"id": i, "embedding": data[dim][i].tolist()} for i in range(NUM_ELEMENTS)]
-    client.insert(collection_name=collection_name, data=insert_data)
-
-def milvus_search(client, collection_name, distance_type, search_data):
-    res = client.search(
-        collection_name=collection_name,
-        data=[search_data],
-        search_params={"metric_type": distance_type.upper()}, # Search parameters
-    )
-    rowids = [result['id'] for result in res[0]]
-    return rowids
-
-def milvus_create_table(client, collection_name, distance_type, dim):
-    from pymilvus import DataType
-
-    schema = client.create_schema(enable_dynamic_field=True)
-    schema.add_field("id", DataType.INT64, is_primary=True)
-    schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
-    index_params = client.prepare_index_params()
-
-    index_params.add_index(
-        field_name="embedding", 
-        metric_type=distance_type.upper(),
-    )
-    client.create_collection(
-        collection_name=collection_name,
-        schema=schema,
-        index_params=index_params,
-        dimension=dim  # The vectors we will use in this demo has 384 dimensions
-    )
-    
-    res = client.get_load_state(
-        collection_name=collection_name
-    )
-    # print(client.describe_index(collection_name,"embedding"))
-    # print(client.describe_index(collection_name,"id"))
-
-def benchmark_milvus(distance_type, dim):
-    result = BenchmarkResult(distance_type=distance_type, dim=dim, insert_time_us=0, search_time_us=0, recall_rate=0, product="milvusLite", ef_construction=0, M=0, ef_search=0)
-    collection_name = f"collection_{distance_type}_{dim}"
-
-    milvus_create_table(client=client, collection_name=collection_name, distance_type=distance_type, dim=dim)
-    
-    # measure insert time
-    insert_time_us, _ = timeit(
-        transactional(lambda: milvus_insert_many(client=client, collection_name=collection_name, dim=dim))
-    )
-
-    result.insert_time_us = insert_time_us / NUM_ELEMENTS
-    plot_data_for_insertion[dim].append(PlotData(result.insert_time_us, f"milvuslite_{distance_type}"))
-
-
-    def search():
-        result = []
-        for i in range(NUM_QUERIES):
-            result.append(
-                milvus_search(client=client, collection_name=collection_name, distance_type=distance_type, search_data=query_data_for_milvus[dim][i])
-            )
-        return result
-
-    search_time_us, results = timeit(search)
-    # console.log(results)
-    recall_rate = np.mean(
-        [
-            np.intersect1d(results[i], correct_labels[distance_type][dim][i]).size
-            / k
-            for i in range(NUM_QUERIES)
-        ]
-    )
-    result = dataclasses.replace(
-        result,
-        search_time_us=search_time_us / NUM_QUERIES,
-        recall_rate=recall_rate,
-    )
-
-    benchmark_results.append(result)
-    plot_data_for_query[dim].append(PlotData(result.search_time_us, f"milvuslite_{distance_type}"))
-    client.drop_collection(collection_name=collection_name)
-    result_table = ResultTable(benchmark_results)
-    console.print(result_table)
-
-
 
 for distance_type in distance_types:
     for dim in DIMS:
-        benchmark_milvus(distance_type, dim)
         for ef_construction, M in hnsw_params:
             benchmark(distance_type, dim, ef_construction, M)
 
@@ -317,11 +215,10 @@ for distance_type in distance_types:
 result_table = ResultTable(benchmark_results)
 console.print(result_table)
 
-
 hnswlib_benchmark_results = []
 console.print("Bencharmk hnswlib as comparison.")
 def benchmark_hnswlib(distance_type, dim, ef_construction, M):
-    result = BenchmarkResult(distance_type, dim, ef_construction, M, 0, 0, 0, 0)
+    result = BenchmarkResult(distance_type, dim, ef_construction, M, 0, 0, 0, 0, "vectorLite")
     hnswlib_index = hnswlib.Index(space=distance_type, dim=dim)
     hnswlib_index.init_index(max_elements=NUM_ELEMENTS, ef_construction=ef_construction, M=M)
 
@@ -372,7 +269,7 @@ brute_force_benchmark_results = []
 console.print("Bencharmk vectorlite brute force(select rowid from my_table order by vector_distance(query_vector, embedding, 'l2')) as comparison.")
 
 def benchmark_brute_force(dim: int):
-    benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0)
+    benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
     table_name = f"table_vectorlite_bf_{dim}"
     cursor.execute(
         f"create table {table_name}(rowid integer primary key, embedding blob)"
@@ -435,7 +332,7 @@ if benchmark_vss and (platform.system().lower() == "linux" or platform.system().
     vss_benchmark_results = []
 
     def benchmark_sqlite_vss(dim: int):
-        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0)
+        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
         table_name = f"table_vss_{dim}"
         cursor.execute(
             f"create virtual table {table_name} using vss0(embedding({dim}))"
@@ -495,7 +392,7 @@ if benchmark_sqlite_vec and (platform.system().lower() == "linux" or platform.sy
     conn.load_extension(sqlite_vec.loadable_path())
 
     def benchmark_sqlite_vec(dim: int):
-        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0)
+        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
         table_name = f"table_vec_{dim}"
         cursor.execute(
             f"create virtual table {table_name} using vec0(rowid integer primary key, embedding float[{dim}])"
@@ -543,6 +440,104 @@ if benchmark_sqlite_vec and (platform.system().lower() == "linux" or platform.sy
 
     vec_result_table = ResultTable(vec_benchmark_results)
     console.print(vec_result_table)
+
+
+import os
+from pymilvus import MilvusClient
+import numpy as np
+
+client = MilvusClient("./milvus_demo6.db")
+
+def milvus_insert(client, collection_name, data):
+    client.insert(collection_name=collection_name, data=data)
+
+def milvus_insert_many(client, collection_name, dim):
+    insert_data = [{"id": i, "embedding": data[dim][i].tolist()} for i in range(NUM_ELEMENTS)]
+    client.insert(collection_name=collection_name, data=insert_data)
+
+def milvus_search(client, collection_name, distance_type, search_data):
+    res = client.search(
+        collection_name=collection_name,
+        data=[search_data],
+        search_params={"metric_type": distance_type.upper()}, # Search parameters
+    )
+    rowids = [result['id'] for result in res[0]]
+    return rowids
+
+def milvus_create_table(client, collection_name, distance_type, dim):
+    from pymilvus import DataType
+
+    schema = client.create_schema(enable_dynamic_field=True)
+    schema.add_field("id", DataType.INT64, is_primary=True)
+    schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+    index_params = client.prepare_index_params()
+
+    index_params.add_index(
+        field_name="embedding", 
+        metric_type=distance_type.upper(),
+    )
+    client.create_collection(
+        collection_name=collection_name,
+        schema=schema,
+        index_params=index_params,
+        dimension=dim  # The vectors we will use in this demo has 384 dimensions
+    )
+    
+    res = client.get_load_state(
+        collection_name=collection_name
+    )
+    # print(client.describe_index(collection_name,"embedding"))
+    # print(client.describe_index(collection_name,"id"))
+
+console.print("Bencharmk milvuslite.")
+
+def benchmark_milvus(distance_type, dim):
+    result = BenchmarkResult(distance_type=distance_type, dim=dim, insert_time_us=0, search_time_us=0, recall_rate=0, product="milvusLite", ef_construction=None, M=None, ef_search=None)
+    collection_name = f"collection_{distance_type}_{dim}"
+
+    milvus_create_table(client=client, collection_name=collection_name, distance_type=distance_type, dim=dim)
+    
+    # measure insert time
+    insert_time_us, _ = timeit(
+        transactional(lambda: milvus_insert_many(client=client, collection_name=collection_name, dim=dim))
+    )
+
+    result.insert_time_us = insert_time_us / NUM_ELEMENTS
+    plot_data_for_insertion[dim].append(PlotData(result.insert_time_us, f"milvuslite_{distance_type}"))
+
+
+    def search():
+        result = []
+        for i in range(NUM_QUERIES):
+            result.append(
+                milvus_search(client=client, collection_name=collection_name, distance_type=distance_type, search_data=query_data_for_milvus[dim][i])
+            )
+        return result
+
+    search_time_us, results = timeit(search)
+    # console.log(results)
+    recall_rate = np.mean(
+        [
+            np.intersect1d(results[i], correct_labels[distance_type][dim][i]).size
+            / k
+            for i in range(NUM_QUERIES)
+        ]
+    )
+    result = dataclasses.replace(
+        result,
+        search_time_us=search_time_us / NUM_QUERIES,
+        recall_rate=recall_rate,
+    )
+
+    benchmark_milvus_results.append(result)
+    plot_data_for_query[dim].append(PlotData(result.search_time_us, f"milvuslite_{distance_type}"))
+    client.drop_collection(collection_name=collection_name)
+
+for distance_type in distance_types:
+    for dim in DIMS:
+        benchmark_milvus(distance_type, dim)
+
+console.print(ResultTable(benchmark_milvus_results))
 
 import plot
 def plot_figures():

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,4 +1,3 @@
-import json
 import time
 from typing import Literal, Optional, List
 import numpy as np
@@ -139,7 +138,6 @@ class PlotData:
     time_taken_us: float
     column: str
 
-benchmark_milvus_results = []
 benchmark_results = []
 plot_data_for_insertion = defaultdict(list)
 plot_data_for_query = defaultdict(list)
@@ -490,7 +488,7 @@ def milvus_create_table(client, collection_name, distance_type, dim):
     # print(client.describe_index(collection_name,"id"))
 
 console.print("Bencharmk milvuslite.")
-
+benchmark_milvus_results = []
 def benchmark_milvus(distance_type, dim):
     result = BenchmarkResult(distance_type=distance_type, dim=dim, insert_time_us=0, search_time_us=0, recall_rate=0, product="milvusLite", ef_construction=None, M=None, ef_search=None)
     collection_name = f"collection_{distance_type}_{dim}"

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -5,3 +5,4 @@ rich>=13.7
 hnswlib>=0.8
 matplotlib
 pandas
+pymilvus


### PR DESCRIPTION
```
Benchmarking using 3000 randomly vectors. 100 10-neariest neighbor queries will be performed on each case.
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
┃ product    ┃ distance ┃ vector    ┃ ef           ┃    ┃ ef     ┃ insert_time ┃ search_time ┃ recall ┃
┃ name       ┃ type     ┃ dimension ┃ construction ┃ M  ┃ search ┃ per vector  ┃ per query   ┃ rate   ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
│ vectorLite │ l2       │ 128       │ 100          │ 30 │ 10     │ 73.58 us    │ 15.00 us    │ 59.20% │
│ vectorLite │ l2       │ 128       │ 100          │ 30 │ 50     │ 73.58 us    │ 46.32 us    │ 94.10% │
│ vectorLite │ l2       │ 128       │ 100          │ 30 │ 100    │ 73.58 us    │ 73.04 us    │ 99.00% │
│ vectorLite │ l2       │ 512       │ 100          │ 30 │ 10     │ 225.71 us   │ 70.54 us    │ 45.30% │
│ vectorLite │ l2       │ 512       │ 100          │ 30 │ 50     │ 225.71 us   │ 188.79 us   │ 84.70% │
│ vectorLite │ l2       │ 512       │ 100          │ 30 │ 100    │ 225.71 us   │ 273.21 us   │ 95.80% │
│ vectorLite │ l2       │ 1536      │ 100          │ 30 │ 10     │ 728.35 us   │ 219.49 us   │ 37.90% │
│ vectorLite │ l2       │ 1536      │ 100          │ 30 │ 50     │ 728.35 us   │ 721.59 us   │ 80.20% │
│ vectorLite │ l2       │ 1536      │ 100          │ 30 │ 100    │ 728.35 us   │ 1108.48 us  │ 93.20% │
│ vectorLite │ l2       │ 3000      │ 100          │ 30 │ 10     │ 1934.85 us  │ 1490.12 us  │ 36.60% │
│ vectorLite │ l2       │ 3000      │ 100          │ 30 │ 50     │ 1934.85 us  │ 2697.82 us  │ 80.10% │
│ vectorLite │ l2       │ 3000      │ 100          │ 30 │ 100    │ 1934.85 us  │ 2592.77 us  │ 94.10% │
│ vectorLite │ cosine   │ 128       │ 100          │ 30 │ 10     │ 121.62 us   │ 30.70 us    │ 58.90% │
│ vectorLite │ cosine   │ 128       │ 100          │ 30 │ 50     │ 121.62 us   │ 74.25 us    │ 93.00% │
│ vectorLite │ cosine   │ 128       │ 100          │ 30 │ 100    │ 121.62 us   │ 213.78 us   │ 98.80% │
│ vectorLite │ cosine   │ 512       │ 100          │ 30 │ 10     │ 285.96 us   │ 51.90 us    │ 48.90% │
│ vectorLite │ cosine   │ 512       │ 100          │ 30 │ 50     │ 285.96 us   │ 203.59 us   │ 86.60% │
│ vectorLite │ cosine   │ 512       │ 100          │ 30 │ 100    │ 285.96 us   │ 248.33 us   │ 96.90% │
│ vectorLite │ cosine   │ 1536      │ 100          │ 30 │ 10     │ 793.06 us   │ 231.40 us   │ 45.70% │
│ vectorLite │ cosine   │ 1536      │ 100          │ 30 │ 50     │ 793.06 us   │ 756.16 us   │ 83.70% │
│ vectorLite │ cosine   │ 1536      │ 100          │ 30 │ 100    │ 793.06 us   │ 1287.76 us  │ 94.80% │
│ vectorLite │ cosine   │ 3000      │ 100          │ 30 │ 10     │ 1528.95 us  │ 499.85 us   │ 41.70% │
│ vectorLite │ cosine   │ 3000      │ 100          │ 30 │ 50     │ 1528.95 us  │ 1253.44 us  │ 82.20% │
│ vectorLite │ cosine   │ 3000      │ 100          │ 30 │ 100    │ 1528.95 us  │ 2025.99 us  │ 94.70% │
└────────────┴──────────┴───────────┴──────────────┴────┴────────┴─────────────┴─────────────┴────────┘
Bencharmk hnswlib as comparison.
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━┳━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━┓
┃ product ┃ distance ┃ vector    ┃ ef           ┃    ┃ ef     ┃ insert_time ┃ search_time ┃ recall ┃
┃ name    ┃ type     ┃ dimension ┃ construction ┃ M  ┃ search ┃ per vector  ┃ per query   ┃ rate   ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━╇━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━┩
│ hnswlib │ l2       │ 128       │ 100          │ 30 │ 10     │ 33.03 us    │ 24.43 us    │ 58.30% │
│ hnswlib │ l2       │ 128       │ 100          │ 30 │ 50     │ 33.03 us    │ 79.29 us    │ 94.20% │
│ hnswlib │ l2       │ 128       │ 100          │ 30 │ 100    │ 33.03 us    │ 129.53 us   │ 99.10% │
│ hnswlib │ l2       │ 512       │ 100          │ 30 │ 10     │ 87.13 us    │ 89.03 us    │ 45.30% │
│ hnswlib │ l2       │ 512       │ 100          │ 30 │ 50     │ 87.13 us    │ 253.88 us   │ 84.10% │
│ hnswlib │ l2       │ 512       │ 100          │ 30 │ 100    │ 87.13 us    │ 469.24 us   │ 95.80% │
│ hnswlib │ l2       │ 1536      │ 100          │ 30 │ 10     │ 451.30 us   │ 423.50 us   │ 37.90% │
│ hnswlib │ l2       │ 1536      │ 100          │ 30 │ 50     │ 451.30 us   │ 1018.48 us  │ 79.80% │
│ hnswlib │ l2       │ 1536      │ 100          │ 30 │ 100    │ 451.30 us   │ 1796.62 us  │ 93.30% │
│ hnswlib │ l2       │ 3000      │ 100          │ 30 │ 10     │ 1306.09 us  │ 1320.64 us  │ 36.80% │
│ hnswlib │ l2       │ 3000      │ 100          │ 30 │ 50     │ 1306.09 us  │ 2893.98 us  │ 79.90% │
│ hnswlib │ l2       │ 3000      │ 100          │ 30 │ 100    │ 1306.09 us  │ 3660.10 us  │ 94.20% │
│ hnswlib │ cosine   │ 128       │ 100          │ 30 │ 10     │ 27.54 us    │ 21.83 us    │ 58.50% │
│ hnswlib │ cosine   │ 128       │ 100          │ 30 │ 50     │ 27.54 us    │ 81.06 us    │ 93.00% │
│ hnswlib │ cosine   │ 128       │ 100          │ 30 │ 100    │ 27.54 us    │ 132.62 us   │ 98.80% │
│ hnswlib │ cosine   │ 512       │ 100          │ 30 │ 10     │ 87.91 us    │ 93.10 us    │ 48.40% │
│ hnswlib │ cosine   │ 512       │ 100          │ 30 │ 50     │ 87.91 us    │ 243.28 us   │ 87.00% │
│ hnswlib │ cosine   │ 512       │ 100          │ 30 │ 100    │ 87.91 us    │ 364.17 us   │ 97.00% │
│ hnswlib │ cosine   │ 1536      │ 100          │ 30 │ 10     │ 375.64 us   │ 395.59 us   │ 45.20% │
│ hnswlib │ cosine   │ 1536      │ 100          │ 30 │ 50     │ 375.64 us   │ 1180.84 us  │ 83.30% │
│ hnswlib │ cosine   │ 1536      │ 100          │ 30 │ 100    │ 375.64 us   │ 1752.67 us  │ 94.80% │
│ hnswlib │ cosine   │ 3000      │ 100          │ 30 │ 10     │ 914.96 us   │ 1009.29 us  │ 42.30% │
│ hnswlib │ cosine   │ 3000      │ 100          │ 30 │ 50     │ 914.96 us   │ 2154.70 us  │ 82.30% │
│ hnswlib │ cosine   │ 3000      │ 100          │ 30 │ 100    │ 914.96 us   │ 2520.03 us  │ 94.40% │
└─────────┴──────────┴───────────┴──────────────┴────┴────────┴─────────────┴─────────────┴────────┘
Bencharmk vectorlite brute force(select rowid from my_table order by vector_distance(query_vector, embedding, 'l2')) as comparison.
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ product                ┃ distance ┃ vector    ┃ insert_time ┃ search_time ┃ recall  ┃
┃ name                   ┃ type     ┃ dimension ┃ per vector  ┃ per query   ┃ rate    ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━┩
│ vectorLite_brute_force │ l2       │ 128       │ 1.49 us     │ 426.82 us   │ 100.00% │
│ vectorLite_brute_force │ l2       │ 512       │ 2.71 us     │ 940.02 us   │ 100.00% │
│ vectorLite_brute_force │ l2       │ 1536      │ 3.79 us     │ 3628.19 us  │ 100.00% │
│ vectorLite_brute_force │ l2       │ 3000      │ 5.95 us     │ 6130.14 us  │ 100.00% │
└────────────────────────┴──────────┴───────────┴─────────────┴─────────────┴─────────┘
Bencharmk milvuslite.
┏━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ product    ┃ distance ┃ vector    ┃ insert_time ┃ search_time ┃ recall  ┃
┃ name       ┃ type     ┃ dimension ┃ per vector  ┃ per query   ┃ rate    ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━┩
│ milvusLite │ l2       │ 128       │ 116.61 us   │ 1690.98 us  │ 100.00% │
│ milvusLite │ l2       │ 512       │ 374.70 us   │ 971.58 us   │ 100.00% │
│ milvusLite │ l2       │ 1536      │ 3651.94 us  │ 1965.66 us  │ 100.00% │
│ milvusLite │ l2       │ 3000      │ 6911.08 us  │ 3045.92 us  │ 100.00% │
│ milvusLite │ cosine   │ 128       │ 133.97 us   │ 1566.03 us  │ 100.00% │
│ milvusLite │ cosine   │ 512       │ 590.21 us   │ 1926.55 us  │ 100.00% │
│ milvusLite │ cosine   │ 1536      │ 3389.90 us  │ 3407.55 us  │ 100.00% │
│ milvusLite │ cosine   │ 3000      │ 7883.70 us  │ 5878.36 us  │ 100.00% │
└────────────┴──────────┴───────────┴─────────────┴─────────────┴─────────┘
```