### PR TITLE
[VSCode] Created devcontainers files to develop inside the container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y \
+    ninja-build \
+    g++ \
+    python3 \
+    curl \
+    zip \
+    unzip \
+    git \
+    pkg-config \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install cmake 
+ENV CMAKE_VERSION=3.29.2
+
+RUN curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh" -o cmake.sh \
+    && chmod +x cmake.sh \
+    && ./cmake.sh --skip-license --prefix=/usr/local \
+    && rm cmake.sh
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "."
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Created the vscode devcontainer files and Dockerfile to speed up our develop environment setup using the VSCode Remote Extension.
- Manual Tests, build the source code using the VSCode + Remote Extension:
  - [x] Windows with Docker Desktop
  - [x] Ubuntu 22.04