### PR TITLE
Refactor benchmark suite: pytest-benchmark, new backends, ergonomics

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -21,6 +21,52 @@ per cell.
   (standard on Homebrew, python.org installer, and modern Linux distro
   Pythons; see [SQLite driver](#sqlite-driver) below)
 
+## Choosing a Python interpreter
+
+The benchmark uses Python's stdlib `sqlite3` module, which links against
+whatever SQLite the interpreter was built with. SQLite versions vary
+significantly across Python distributions, even at the same Python
+version. Vectorlite itself loads on virtually any SQLite, but its
+metadata-filter (rowid pushdown) feature requires **SQLite >= 3.38** -
+the benchmark does not exercise that path, so any SQLite that loads
+the extension at all will run the benchmark. The session header reports
+the loaded SQLite version and prints a NOTE line if it is below 3.38.
+
+Empirically, here is what common Python distributions ship:
+
+| Distribution                        | SQLite          | Metadata filter (>= 3.38)? |
+|-------------------------------------|-----------------|----------------------------|
+| python.org installer 3.10           | 3.36            | no                         |
+| python.org installer 3.11           | 3.39            | yes                        |
+| python.org installer 3.12           | 3.43            | yes                        |
+| python.org installer 3.13+          | 3.45+           | yes                        |
+| Homebrew Python (any version)       | tracks Homebrew's `sqlite` keg, currently ~3.53 | yes |
+| pyenv-built Python (any version)    | tracks the Homebrew/system SQLite at build time | usually yes |
+| Conda / Miniconda Python            | bundled, recent | yes                        |
+| Ubuntu 20.04 system Python (3.8)    | 3.31            | no                         |
+| Ubuntu 22.04 system Python (3.10)   | 3.37            | no (just under!)           |
+| Ubuntu 24.04 system Python (3.12)   | 3.45            | yes                        |
+| Debian 11 system Python             | 3.34            | no                         |
+| Debian 12 system Python             | 3.40            | yes                        |
+| RHEL/Rocky/Alma 9 system Python     | 3.34            | no                         |
+| Official `python:3.X` Docker image  | tracks the Debian base; recent tags are fine | usually yes |
+
+**Rule of thumb:** Python 3.11+ from python.org, Homebrew, or pyenv is
+always fine. System Python on Linux is unreliable below
+Ubuntu 24.04 / Debian 12 / RHEL 10 / Alpine 3.19+.
+
+To check what your interpreter has:
+
+```bash
+python -c "import sqlite3; print(sqlite3.sqlite_version)"
+```
+
+If the version is too old and you cannot upgrade Python, switch to
+[apsw](https://rogerbinns.github.io/apsw/), which bundles its own
+SQLite (currently 3.53). The benchmark targets stdlib `sqlite3`
+specifically, but the rest of vectorlite's documentation and examples
+work with apsw.
+
 ## Quick start
 
 ```bash

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,6 +7,8 @@ Compares vectorlite's vector-search performance and recall against:
 - `sqlite_vss` _(optional)_
 - `sqlite_vec` _(optional)_
 - `milvus-lite` _(optional)_
+- `libsql` _(optional)_ — Turso/libSQL with built-in DiskANN vector index
+- `sqlite-vector` _(optional)_ — sqliteai SIMD-accelerated full scan
 
 Each cell is benchmarked with `pytest-benchmark`, which auto-calibrates
 warm-up and round count and reports min / max / mean / median / stddev / IQR
@@ -157,6 +159,8 @@ Driven by environment variables; defaults in `benchmark/benchmark.py`.
 | `BENCHMARK_VSS` | `0` | `1` enables the `sqlite_vss` backend (Linux/macOS). |
 | `BENCHMARK_SQLITE_VEC` | `0` | `1` enables the `sqlite_vec` backend (Linux/macOS). |
 | `BENCHMARK_MILVUS_LITE` | `0` | `1` enables the `milvus-lite` backend (Linux/macOS). |
+| `BENCHMARK_LIBSQL` | `0` | `1` enables the `libsql` backend (Linux/macOS). |
+| `BENCHMARK_SQLITE_VECTOR` | `0` | `1` enables the `sqlite-vector` backend (Linux/macOS). |
 
 Other constants (vector dimensions, distance metrics, HNSW parameters,
 `ef_search` values, query count) are at the top of `benchmark.py` and are

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,6 +12,15 @@ Each cell is benchmarked with `pytest-benchmark`, which auto-calibrates
 warm-up and round count and reports min / max / mean / median / stddev / IQR
 per cell.
 
+## Requirements
+
+- **Python >= 3.10** (driven by NumPy 2.4 wheel availability; enforced
+  at session start by `benchmark/conftest.py` so wrong-Python runs fail
+  with a clear message instead of cryptic install errors)
+- A Python interpreter built with `--enable-loadable-sqlite-extensions`
+  (standard on Homebrew, python.org installer, and modern Linux distro
+  Pythons; see [SQLite driver](#sqlite-driver) below)
+
 ## Quick start
 
 ```bash

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,164 @@
+# Vectorlite benchmark
+
+Compares vectorlite's vector-search performance and recall against:
+
+- `hnswlib` (in-memory, the library vectorlite is built on)
+- `vectorlite` brute-force (`SELECT ... ORDER BY vector_distance(...)`)
+- `sqlite_vss` _(optional)_
+- `sqlite_vec` _(optional)_
+- `milvus-lite` _(optional)_
+
+Each cell is benchmarked with `pytest-benchmark`, which auto-calibrates
+warm-up and round count and reports min / max / mean / median / stddev / IQR
+per cell.
+
+## Quick start
+
+```bash
+pip install -r benchmark/requirements.txt           # core deps (PyPI vectorlite)
+pip install -r benchmark/requirements-extra.txt     # +sqlite_vss, sqlite_vec
+
+# Run the default backends (vectorlite, hnswlib, vectorlite brute force):
+pytest benchmark/test_benchmark.py --benchmark-json=bench.json
+
+# Render the two PNG figures + a recall.csv companion next to them:
+python benchmark/plot.py bench.json
+```
+
+## Choosing which vectorlite to benchmark
+
+By default the benchmark loads the vectorlite shared library shipped with
+the installed `vectorlite_py` wheel. To benchmark something else there are
+two equivalent options:
+
+```bash
+# Command-line flag (highest priority):
+pytest benchmark/test_benchmark.py \
+    --vectorlite-path=build/release/vectorlite/vectorlite.dylib
+
+# Environment variable (also picked up by examples/ and tests/):
+VECTORLITE_PATH=build/release/vectorlite/vectorlite.dylib \
+    pytest benchmark/test_benchmark.py
+```
+
+The session header prints which file was actually loaded so you can
+double-check before trusting the numbers:
+
+```
+vectorlite: /path/to/build/release/vectorlite/vectorlite.dylib
+            (2.47 MiB, sqlite3 3.50.4)
+```
+
+### Don't benchmark a debug build
+
+`build/dev/vectorlite/vectorlite.dylib` exists right next to the release
+build and is roughly **10× slower**. The benchmark detects path patterns
+that look like debug builds (`/build/dev/`, `/Debug/`, `/debug/`) and
+prints a `WARNING` line plus a Python `UserWarning`:
+
+```
+vectorlite: /path/to/build/dev/vectorlite/vectorlite.dylib
+            (8.55 MiB, sqlite3 3.50.4)
+            WARNING: path looks like a debug build; benchmark numbers will not be representative.
+```
+
+If you really do want to compare debug-build perf for some reason, the
+warning is non-fatal — the run still proceeds.
+
+## Comparing two builds (before / after)
+
+`pytest-benchmark` saves results under `.benchmarks/` and can diff them.
+Useful when changing vectorlite internals and you want to know whether a
+change moved the needle:
+
+```bash
+# Take a baseline of the released library:
+pytest benchmark/test_benchmark.py --benchmark-save=baseline
+
+# ... edit vectorlite, rebuild ...
+cmake --build build/release -j8
+
+# Run again against the new local build:
+pytest benchmark/test_benchmark.py \
+    --vectorlite-path=build/release/vectorlite/vectorlite.dylib \
+    --benchmark-compare=baseline \
+    --benchmark-compare-fail=median:5%
+```
+
+`--benchmark-compare-fail=median:5%` makes pytest exit non-zero if any
+median regressed by more than 5 %. Useful in a CI job.
+
+To list saved baselines: `python -m pytest_benchmark list`. To delete
+them: `rm -r .benchmarks/`.
+
+## Configuration
+
+Driven by environment variables; defaults in `benchmark/benchmark.py`.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `NUM_ELEMENTS` | `3000` | Number of random vectors indexed per case. |
+| `VECTORLITE_PATH` | wheel default | Vectorlite shared library to load. |
+| `BENCHMARK_VSS` | `0` | `1` enables the `sqlite_vss` backend (Linux/macOS). |
+| `BENCHMARK_SQLITE_VEC` | `0` | `1` enables the `sqlite_vec` backend (Linux/macOS). |
+| `BENCHMARK_MILVUS_LITE` | `0` | `1` enables the `milvus-lite` backend (Linux/macOS). |
+
+Other constants (vector dimensions, distance metrics, HNSW parameters,
+`ef_search` values, query count) are at the top of `benchmark.py` and are
+edited in source rather than via environment.
+
+## Useful pytest-benchmark flags
+
+```bash
+# Filter to a subset (test parametrize ids: [<distance>-<dim>-<ef_search>]):
+pytest benchmark/test_benchmark.py -k "search and 1536 and 50"
+
+# Sort the printed table by a specific stat:
+pytest benchmark/test_benchmark.py --benchmark-sort=mean
+
+# Group rows by parameter (default groups by test):
+pytest benchmark/test_benchmark.py --benchmark-group-by=group,param:dim
+
+# Skip generating the JSON file (just print the table):
+pytest benchmark/test_benchmark.py
+```
+
+See `pytest-benchmark`'s docs for the full list:
+<https://pytest-benchmark.readthedocs.io>.
+
+## Output files
+
+After `python benchmark/plot.py bench.json`:
+
+- `vector_insertion_<N>_vectors.png` — bar chart, per-vector insert time vs. dim, one bar per `(product, distance_type)`.
+- `vector_query_<N>_vectors.png` — bar chart, per-query search time vs. dim, one bar per `(product, distance_type, ef_search)`.
+- `vector_query_<N>_vectors_recall.csv` — recall per query cell. Recall isn't a timing metric so it isn't on the bar chart; this file makes sure it isn't lost.
+
+`<N>` is `NUM_ELEMENTS`. The PNGs are written to the current directory by
+default; pass `--output-dir=DIR` to `plot.py` to put them somewhere else.
+
+## File layout
+
+```
+benchmark/
+├─ benchmark.py        # library: BenchmarkData, Backend hierarchy, helpers
+├─ conftest.py         # pytest fixtures and the --vectorlite-path option
+├─ test_benchmark.py   # parametrized pytest-benchmark cases (one per cell)
+├─ plot.py             # JSON -> PNG + recall CSV
+├─ requirements.txt    # core dependencies
+└─ requirements-extra.txt  # sqlite_vss, sqlite_vec
+```
+
+## SQLite driver
+
+The benchmark uses Python's stdlib `sqlite3` rather than `apsw`. Loading
+the vectorlite extension via `conn.load_extension(...)` requires a Python
+interpreter built with `--enable-loadable-sqlite-extensions` (standard on
+Homebrew, python.org installer and modern Linux distro Pythons). If your
+interpreter does not enable that, `conn.enable_load_extension(True)`
+raises `AttributeError` or `OperationalError` and you'll need a different
+Python build (or `apsw`).
+
+The benchmark itself does not use vectorlite's metadata-filter (rowid
+pushdown) feature, so any SQLite version that vectorlite loads on works
+here. The bundled SQLite version is reported in the session header.

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,551 +1,664 @@
+"""Benchmark vectorlite's performance and recall against alternative backends.
+
+Methodology follows
+https://github.com/nmslib/hnswlib/blob/v0.8.0/TESTING_RECALL.md.
+
+Configuration is driven by environment variables:
+
+    NUM_ELEMENTS           number of random vectors to index (default 3000)
+    VECTORLITE_PATH        path to a locally built vectorlite extension
+    BENCHMARK_VSS=1        also benchmark sqlite_vss (Linux/macOS only)
+    BENCHMARK_SQLITE_VEC=1 also benchmark sqlite-vec (Linux/macOS only)
+    BENCHMARK_MILVUS_LITE=1 also benchmark milvus-lite (Linux/macOS only)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import platform
 import time
-from typing import Literal, Optional, List
+from collections import defaultdict
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
+
+import apsw
+import hnswlib
 import numpy as np
 import vectorlite_py
-import apsw
-import dataclasses
-import hnswlib
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.table import Table
-import os
-from collections import defaultdict
+
+import plot
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+NUM_ELEMENTS: int = int(os.environ.get("NUM_ELEMENTS", 3000))
+NUM_QUERIES: int = 100
+K: int = 10  # number of nearest neighbours retrieved per query
+
+DIMS: List[int] = [128, 512, 1536, 3000]
+# 'ip' (inner product) is intentionally excluded - it is not a true metric.
+DISTANCE_TYPES: List[str] = ["l2", "cosine"]
+HNSW_PARAMS: List[Tuple[int, int]] = [(100, 30)]  # (ef_construction, M)
+EF_SEARCH_VALUES: List[int] = [10, 50, 100]
+
+console = Console()
 
 
-"""
-Benchamrk vectorlite's performance and recall rate using method described in https://github.com/nmslib/hnswlib/blob/v0.8.0/TESTING_RECALL.md
-"""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-# Roll our own timeit function to measure time in us and get return value of the func.
-# Why Python's built-in timeit.timeit is not used:
-# 1. it compiles the code passed to it, which is unnecessary overhead.
-# 2. func's return value cannot be obtained directly
-def timeit(func):
+def timeit(func: Callable[[], object]) -> Tuple[float, object]:
+    """Run ``func`` once. Return (elapsed_microseconds, return_value).
+
+    Avoids ``timeit.timeit`` which compiles strings and discards return values.
+    """
     start_us = time.perf_counter_ns() / 1000
     retval = func()
     end_us = time.perf_counter_ns() / 1000
     return end_us - start_us, retval
 
-vectorlite_path = os.environ.get("VECTORLITE_PATH", vectorlite_py.vectorlite_path())
 
-if vectorlite_path != vectorlite_py.vectorlite_path():
-    print(f"Using local vectorlite: {vectorlite_path}")
-
-conn = apsw.Connection(":memory:")
-conn.enable_load_extension(True)  # enable extension loading
-conn.load_extension(vectorlite_path)  # loads vectorlite
-
-cursor = conn.cursor()
-
-NUM_ELEMENTS = int(os.environ.get("NUM_ELEMENTS", 3000)) # number of vectors 
-NUM_QUERIES = 100  # number of queries
-
-DIMS = [128, 512, 1536, 3000]
-data = {dim: np.float32(np.random.random((NUM_ELEMENTS, dim))) for dim in DIMS}
-data_bytes = {dim: [data[dim][i].tobytes() for i in range(NUM_ELEMENTS)] for dim in DIMS}
-
-query_data = {dim: np.float32(np.random.random((NUM_QUERIES, dim))) for dim in DIMS}
-query_data_bytes = {dim: [query_data[dim][i].tobytes() for i in range(NUM_QUERIES)] for dim in DIMS}
-query_data_for_milvus = {dim: [query_data[dim][i].tolist() for i in range(NUM_QUERIES)] for dim in DIMS}
-
-# search for k nearest neighbors in this benchmark
-k = 10
-
-# (ef_construction, M)
-hnsw_params = [(100, 30)]
-
-# ef_search
-efs = [10, 50, 100]
+def compute_recall(predicted: Sequence[Sequence[int]],
+                   expected: np.ndarray, k: int) -> float:
+    """Mean fraction of true k-NN labels recovered per query."""
+    return float(np.mean([
+        np.intersect1d(predicted[i], expected[i]).size / k
+        for i in range(len(predicted))
+    ]))
 
 
-# 'ip'(inner product) is not tested as it is not an actual metric that measures the distance between two vectors
-distance_types = ["l2", "cosine"]
+def is_supported_platform() -> bool:
+    return platform.system().lower() in ("linux", "darwin")
 
-# Calculate correct results using Brute Force index
-correct_labels = {}
-for distance_type in distance_types:
-    correct_labels[distance_type] = {}
-    for dim in DIMS:
-        bf_index = hnswlib.BFIndex(space=distance_type, dim=dim)
-        bf_index.init_index(max_elements=NUM_ELEMENTS)
-        bf_index.add_items(data[dim])
 
-        labels, distances = bf_index.knn_query(query_data[dim], k=k)
-        assert len(labels) == NUM_QUERIES and len(labels[0]) == k
-        correct_labels[distance_type][dim] = labels
-        del bf_index
+# ---------------------------------------------------------------------------
+# Synthetic dataset and ground truth
+# ---------------------------------------------------------------------------
 
-console = Console()
-console.print(f"Benchmarking using {NUM_ELEMENTS} randomly vectors. {NUM_QUERIES} {k}-neariest neighbor queries will be performed on each case.")
+
+@dataclasses.dataclass
+class BenchmarkData:
+    """Random vectors plus their precomputed brute-force k-NN ground truth."""
+
+    data: dict          # dim -> np.ndarray (NUM_ELEMENTS x dim, float32)
+    data_bytes: dict    # dim -> list[bytes]   (one per element, for SQL inserts)
+    queries: dict       # dim -> np.ndarray (NUM_QUERIES x dim, float32)
+    query_bytes: dict   # dim -> list[bytes]
+    correct_labels: dict  # distance_type -> dim -> np.ndarray (NUM_QUERIES x K)
+
+    @classmethod
+    def generate(cls, dims: Sequence[int], num_elements: int,
+                 num_queries: int, k: int,
+                 distance_types: Sequence[str]) -> "BenchmarkData":
+        data = {d: np.float32(np.random.random((num_elements, d))) for d in dims}
+        data_bytes = {
+            d: [data[d][i].tobytes() for i in range(num_elements)] for d in dims
+        }
+        queries = {
+            d: np.float32(np.random.random((num_queries, d))) for d in dims
+        }
+        query_bytes = {
+            d: [queries[d][i].tobytes() for i in range(num_queries)] for d in dims
+        }
+
+        correct_labels: dict = {}
+        for dt in distance_types:
+            correct_labels[dt] = {}
+            for d in dims:
+                bf = hnswlib.BFIndex(space=dt, dim=d)
+                bf.init_index(max_elements=num_elements)
+                bf.add_items(data[d])
+                labels, _ = bf.knn_query(queries[d], k=k)
+                assert len(labels) == num_queries and len(labels[0]) == k
+                correct_labels[dt][d] = labels
+                del bf
+
+        return cls(data, data_bytes, queries, query_bytes, correct_labels)
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
 
 @dataclasses.dataclass
 class BenchmarkResult:
-    distance_type: Literal["l2", "cosine"]
+    product: str
+    distance_type: str
     dim: int
-    ef_construction: Optional[int]
-    M: Optional[int]
-    ef_search: Optional[int]
-    insert_time_us: float  # in micro seconds, per vector
-    search_time_us: float  # in micro seconds, per query
+    insert_time_us: float
+    search_time_us: float
     recall_rate: float
-    product: Optional[str]
+    ef_construction: Optional[int] = None
+    M: Optional[int] = None
+    ef_search: Optional[int] = None
 
 
 @dataclasses.dataclass
 class ResultTable:
+    """Render a list of ``BenchmarkResult`` as a rich Table."""
+
     results: List[BenchmarkResult]
 
-    def __rich_console__(
-        self, console: Console, options: ConsoleOptions
-    ) -> RenderResult:
+    def __rich_console__(self, console: Console,
+                         options: ConsoleOptions) -> RenderResult:
+        if not self.results:
+            yield Table()
+            return
+
+        show_hnsw = self.results[0].ef_construction is not None
+
         table = Table()
         table.add_column("product\nname")
         table.add_column("distance\ntype")
         table.add_column("vector\ndimension")
-        if self.results[0].ef_construction is not None:
+        if show_hnsw:
             table.add_column("ef\nconstruction")
             table.add_column("M")
             table.add_column("ef\nsearch")
         table.add_column("insert_time\nper vector")
         table.add_column("search_time\nper query")
         table.add_column("recall\nrate")
-        for result in self.results:
-            if self.results[0].ef_construction is not None:
-                table.add_row(
-                    result.product,
-                    result.distance_type,
-                    str(result.dim),
-                    str(result.ef_construction),
-                    str(result.M),
-                    str(result.ef_search),
-                    f"{result.insert_time_us:.2f} us",
-                    f"{result.search_time_us:.2f} us",
-                    f"{result.recall_rate * 100:.2f}%",
-                )
-            else:
-                table.add_row(
-                    result.product,
-                    result.distance_type,
-                    str(result.dim),
-                    f"{result.insert_time_us:.2f} us",
-                    f"{result.search_time_us:.2f} us",
-                    f"{result.recall_rate * 100:.2f}%",
-                )
+
+        for r in self.results:
+            row = [r.product, r.distance_type, str(r.dim)]
+            if show_hnsw:
+                row += [str(r.ef_construction), str(r.M), str(r.ef_search)]
+            row += [
+                f"{r.insert_time_us:.2f} us",
+                f"{r.search_time_us:.2f} us",
+                f"{r.recall_rate * 100:.2f}%",
+            ]
+            table.add_row(*row)
+
         yield table
+
+
+# ---------------------------------------------------------------------------
+# Backend protocol
+# ---------------------------------------------------------------------------
+
+
+class Backend:
+    """Common interface for every system under test.
+
+    A backend handles the lifecycle of one (distance_type, dim, hnsw_params)
+    configuration. ``run_backend`` drives it end to end; the backend just
+    declares its capabilities and implements the four lifecycle hooks.
+    """
+
+    name: str = "<unknown>"
+    plot_label: str = "<unknown>"  # may include {distance_type} / {ef_search}
+    uses_hnsw_params: bool = False
+    supports_ef_search: bool = False
+    supported_distances: Sequence[str] = DISTANCE_TYPES
+    # Some backends should not appear in the query plot at high N because
+    # their search time dwarfs every other point. Override per-backend.
+    include_in_query_plot: bool = True
+
+    # --- lifecycle (override) -------------------------------------------------
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        raise NotImplementedError
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        raise NotImplementedError
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        raise NotImplementedError
+
+    def teardown(self) -> None:
+        pass
+
+    # --- helpers --------------------------------------------------------------
+
+    def insertion_label(self, distance_type: str) -> str:
+        return self.plot_label.format(distance_type=distance_type, ef_search="")
+
+    def query_label(self, distance_type: str, ef_search: Optional[int]) -> str:
+        return self.plot_label.format(
+            distance_type=distance_type,
+            ef_search=f"_ef_{ef_search}" if ef_search is not None else "",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete backends
+# ---------------------------------------------------------------------------
+
+
+class _SqlBackend(Backend):
+    """Shared scaffolding for backends that use the apsw cursor."""
+
+    def __init__(self, cursor: apsw.Cursor, data: BenchmarkData) -> None:
+        self.cursor = cursor
+        self.data = data
+        self._table: Optional[str] = None
+
+    def _insert_rows(self) -> None:
+        rows = [(i, self.data.data_bytes[self._dim][i])
+                for i in range(NUM_ELEMENTS)]
+        self.cursor.execute("BEGIN TRANSACTION;")
+        self.cursor.executemany(
+            f"insert into {self._table}(rowid, embedding) values (?, ?)", rows)
+        self.cursor.execute("COMMIT;")
+
+    def teardown(self) -> None:
+        if self._table is not None:
+            self.cursor.execute(f"drop table {self._table}")
+            self._table = None
+
+
+class VectorliteBackend(_SqlBackend):
+    name = "vectorlite"
+    plot_label = "vectorlite_{distance_type}{ef_search}"
+    uses_hnsw_params = True
+    supports_ef_search = True
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        self._table = f"table_{distance_type}_{dim}_{ef_construction}_{M}"
+        self.cursor.execute(
+            f"create virtual table {self._table} using vectorlite("
+            f"embedding float32[{dim}] {distance_type}, "
+            f"hnsw(max_elements={NUM_ELEMENTS}, "
+            f"ef_construction={ef_construction}, M={M}))"
+        )
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        self._insert_rows()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            results.append(self.cursor.execute(
+                f"select rowid from {self._table} "
+                f"where knn_search(embedding, knn_param(?, ?, ?))",
+                (self.data.query_bytes[dim][i], K, ef_search),
+            ).fetchall())
+        return results
+
+
+class VectorliteBruteForceBackend(_SqlBackend):
+    name = "vectorlite_brute_force"
+    plot_label = "vectorlite_scalar_brute_force"
+    supported_distances = ["l2"]
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        self._table = f"table_vectorlite_bf_{dim}"
+        self.cursor.execute(
+            f"create table {self._table}"
+            f"(rowid integer primary key, embedding blob)"
+        )
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        self._insert_rows()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            results.append(self.cursor.execute(
+                f"select rowid from {self._table} "
+                f"order by vector_distance(?, embedding, 'l2') asc limit {K}",
+                [self.data.query_bytes[dim][i]],
+            ).fetchall())
+        return results
+
+
+class HnswlibBackend(Backend):
+    name = "hnswlib"
+    plot_label = "hnswlib_{distance_type}{ef_search}"
+    uses_hnsw_params = True
+    supports_ef_search = True
+
+    def __init__(self, data: BenchmarkData) -> None:
+        self.data = data
+        self._index: Optional[hnswlib.Index] = None
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._index = hnswlib.Index(space=distance_type, dim=dim)
+        self._index.init_index(
+            max_elements=NUM_ELEMENTS,
+            ef_construction=ef_construction,
+            M=M,
+        )
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        assert self._index is not None
+        self._index.add_items(self.data.data[dim])
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        assert self._index is not None
+        if ef_search is not None:
+            self._index.set_ef(ef_search)
+        results = []
+        for i in range(NUM_QUERIES):
+            labels, _ = self._index.knn_query(self.data.queries[dim][i], k=K)
+            results.append(labels)
+        return results
+
+    def teardown(self) -> None:
+        self._index = None
+
+
+class SqliteVssBackend(_SqlBackend):
+    name = "sqlite_vss"
+    plot_label = "sqlite_vss"
+    supported_distances = ["l2"]
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        self._table = f"table_vss_{dim}"
+        self.cursor.execute(
+            f"create virtual table {self._table} using vss0(embedding({dim}))"
+        )
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        self._insert_rows()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            results.append(self.cursor.execute(
+                f"select rowid from {self._table} "
+                f"where vss_search(embedding, ?) limit {K}",
+                (self.data.query_bytes[dim][i],),
+            ).fetchall())
+        return results
+
+
+class SqliteVecBackend(_SqlBackend):
+    name = "sqlite_vec"
+    plot_label = "sqlite_vec"
+    supported_distances = ["l2"]
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        self._table = f"table_vec_{dim}"
+        self.cursor.execute(
+            f"create virtual table {self._table} using vec0("
+            f"rowid integer primary key, embedding float[{dim}])"
+        )
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        self._insert_rows()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            results.append(self.cursor.execute(
+                f"select rowid from {self._table} "
+                f"where embedding match ? and k = {K}",
+                (self.data.query_bytes[dim][i],),
+            ).fetchall())
+        return results
+
+    @property
+    def include_in_query_plot(self) -> bool:  # type: ignore[override]
+        # sqlite-vec's brute force search dominates the plot at high N.
+        return NUM_ELEMENTS < 10000
+
+
+class MilvusLiteBackend(Backend):
+    name = "milvus_lite"
+    plot_label = "milvuslite_{distance_type}{ef_search}"
+
+    def __init__(self, data: BenchmarkData, db_path: str = "./milvus_lite_demo.db") -> None:
+        from pymilvus import MilvusClient
+        self.data = data
+        self._client = MilvusClient(db_path)
+        self._collection: Optional[str] = None
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        from pymilvus import DataType
+        self._collection = f"collection_{distance_type}_{dim}"
+
+        schema = self._client.create_schema(enable_dynamic_field=True)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        index_params = self._client.prepare_index_params()
+        index_params.add_index(
+            field_name="embedding",
+            metric_type=distance_type.upper(),
+        )
+        self._client.create_collection(
+            collection_name=self._collection,
+            schema=schema,
+            index_params=index_params,
+            dimension=dim,
+        )
+        self._client.get_load_state(collection_name=self._collection)
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        rows = [
+            {"id": i, "embedding": self.data.data[dim][i].tolist()}
+            for i in range(NUM_ELEMENTS)
+        ]
+        self._client.insert(collection_name=self._collection, data=rows)
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            response = self._client.search(
+                collection_name=self._collection,
+                data=[self.data.queries[dim][i].tolist()],
+                search_params={"metric_type": distance_type.upper()},
+            )
+            results.append([hit["id"] for hit in response[0]])
+        return results
+
+    def teardown(self) -> None:
+        if self._collection is not None:
+            self._client.drop_collection(collection_name=self._collection)
+            self._collection = None
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
 
 @dataclasses.dataclass
 class PlotData:
     time_taken_us: float
     column: str
 
-benchmark_results = []
-plot_data_for_insertion = defaultdict(list)
-plot_data_for_query = defaultdict(list)
 
-def transactional(func):
-    # def wrapper():
-    #     with conn:
-    #         func()
-    # return wrapper
-    def wrapper():
-        cursor.execute("BEGIN TRANSACTION;")
-        func()
-        cursor.execute("COMMIT;")
-    return wrapper
+@dataclasses.dataclass
+class BenchmarkSuite:
+    """Accumulates results and per-dim plot points across backends."""
+
+    plot_insertion: dict = dataclasses.field(default_factory=lambda: defaultdict(list))
+    plot_query: dict = dataclasses.field(default_factory=lambda: defaultdict(list))
+
+    def record_insertion(self, dim: int, label: str, time_us: float) -> None:
+        self.plot_insertion[dim].append(PlotData(time_us, label))
+
+    def record_query(self, dim: int, label: str, time_us: float) -> None:
+        self.plot_query[dim].append(PlotData(time_us, label))
+
+    def write_plots(self, num_elements: int) -> None:
+        for kind, points in (("insertion", self.plot_insertion),
+                             ("query", self.plot_query)):
+            if not points:
+                continue
+            dims = sorted(points.keys())
+            columns = ["dim"] + [p.column for p in points[dims[0]]]
+            rows = [[d] + [p.time_taken_us for p in points[d]] for d in dims]
+            plot.plot(f"vector_{kind}_{num_elements}_vectors", columns, rows)
 
 
+def run_backend(backend: Backend, data: BenchmarkData,
+                suite: BenchmarkSuite,
+                distance_types: Sequence[str] = DISTANCE_TYPES,
+                dims: Sequence[int] = DIMS,
+                hnsw_params: Sequence[Tuple[int, int]] = HNSW_PARAMS,
+                ef_values: Sequence[int] = EF_SEARCH_VALUES,
+                ) -> List[BenchmarkResult]:
+    """Run one backend across all configurations; return its results."""
+    param_combos: Iterable[Tuple[Optional[int], Optional[int]]] = (
+        hnsw_params if backend.uses_hnsw_params else [(None, None)]
+    )
+    ef_iter: Sequence[Optional[int]] = (
+        ef_values if backend.supports_ef_search else [None]
+    )
+    relevant_distances = [
+        d for d in distance_types if d in backend.supported_distances
+    ]
 
-def benchmark(distance_type, dim, ef_constructoin, M):
-    result = BenchmarkResult(distance_type, dim, ef_constructoin, M, 0, 0, 0, 0, "vectorLite")
-    table_name = f"table_{distance_type}_{dim}_{ef_constructoin}_{M}"
-    cursor.execute(
-        f"create virtual table {table_name} using vectorlite(embedding float32[{dim}] {distance_type}, hnsw(max_elements={NUM_ELEMENTS}, ef_construction={ef_constructoin}, M={M}))"
+    results: List[BenchmarkResult] = []
+
+    for distance_type in relevant_distances:
+        for dim in dims:
+            for ef_construction, M in param_combos:
+                backend.setup(distance_type, dim, ef_construction, M)
+                try:
+                    insert_total_us, _ = timeit(
+                        lambda: backend.do_insert(distance_type, dim))
+                    insert_time_us = insert_total_us / NUM_ELEMENTS
+                    suite.record_insertion(
+                        dim, backend.insertion_label(distance_type),
+                        insert_time_us)
+
+                    for ef in ef_iter:
+                        search_total_us, query_results = timeit(
+                            lambda: backend.do_search(distance_type, dim, ef))
+                        search_time_us = search_total_us / NUM_QUERIES
+                        recall = compute_recall(
+                            query_results,
+                            data.correct_labels[distance_type][dim], K)
+
+                        results.append(BenchmarkResult(
+                            product=backend.name,
+                            distance_type=distance_type,
+                            dim=dim,
+                            insert_time_us=insert_time_us,
+                            search_time_us=search_time_us,
+                            recall_rate=recall,
+                            ef_construction=ef_construction,
+                            M=M,
+                            ef_search=ef,
+                        ))
+                        if backend.include_in_query_plot:
+                            suite.record_query(
+                                dim,
+                                backend.query_label(distance_type, ef),
+                                search_time_us)
+                finally:
+                    backend.teardown()
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Optional backend loaders (gated by env vars / platform)
+# ---------------------------------------------------------------------------
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "0") != "0"
+
+
+def collect_optional_backends(cursor: apsw.Cursor, conn: apsw.Connection,
+                              data: BenchmarkData) -> List[Backend]:
+    backends: List[Backend] = []
+    if not is_supported_platform():
+        return backends
+
+    if _env_flag("BENCHMARK_VSS"):
+        # sqlite_vss is not self-contained; on Debian/Ubuntu install:
+        #   sudo apt-get install -y libgomp1 libatlas-base-dev liblapack-dev
+        import sqlite_vss
+        sqlite_vss.load(conn)
+        backends.append(SqliteVssBackend(cursor, data))
+
+    if _env_flag("BENCHMARK_SQLITE_VEC"):
+        import sqlite_vec
+        conn.load_extension(sqlite_vec.loadable_path())
+        backends.append(SqliteVecBackend(cursor, data))
+
+    if _env_flag("BENCHMARK_MILVUS_LITE"):
+        backends.append(MilvusLiteBackend(data))
+
+    return backends
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    vectorlite_path = os.environ.get(
+        "VECTORLITE_PATH", vectorlite_py.vectorlite_path())
+    if vectorlite_path != vectorlite_py.vectorlite_path():
+        console.print(f"Using local vectorlite: {vectorlite_path}")
+
+    conn = apsw.Connection(":memory:")
+    conn.enable_load_extension(True)
+    conn.load_extension(vectorlite_path)
+    cursor = conn.cursor()
+
+    console.print(
+        f"Benchmarking with {NUM_ELEMENTS} random vectors. "
+        f"{NUM_QUERIES} {K}-nearest-neighbour queries per case."
     )
 
-    # measure insert time
-    insert_time_us, _ = timeit(
-        transactional(lambda: cursor.executemany(
-            f"insert into {table_name}(rowid, embedding) values (?, ?)",
-            [(i, data_bytes[dim][i]) for i in range(NUM_ELEMENTS)],
-        ))
-    )
-    result.insert_time_us = insert_time_us / NUM_ELEMENTS
-    plot_data_for_insertion[dim].append(PlotData(result.insert_time_us, f"vectorlite_{distance_type}"))
+    data = BenchmarkData.generate(
+        DIMS, NUM_ELEMENTS, NUM_QUERIES, K, DISTANCE_TYPES)
 
-    for ef in efs:
+    suite = BenchmarkSuite()
 
-        def search():
-            result = []
-            for i in range(NUM_QUERIES):
-                result.append(
-                    cursor.execute(
-                        f"select rowid from {table_name} where knn_search(embedding, knn_param(?, ?, ?))",
-                        (query_data_bytes[dim][i], k, ef),
-                    ).fetchall()
-                )
-            return result
+    # The order here defines column order in plot CSV / PNG output.
+    primary_backends: List[Tuple[Backend, str]] = [
+        (VectorliteBackend(cursor, data),
+         "vectorlite (HNSW virtual table)"),
+        (HnswlibBackend(data),
+         "hnswlib (in-memory, comparison)"),
+        (VectorliteBruteForceBackend(cursor, data),
+         "vectorlite brute force "
+         "(SELECT ... ORDER BY vector_distance(...))"),
+    ]
 
-        search_time_us, results = timeit(search)
-        # console.log(results)
-        recall_rate = np.mean(
-            [
-                np.intersect1d(results[i], correct_labels[distance_type][dim][i]).size
-                / k
-                for i in range(NUM_QUERIES)
-            ]
-        )
-        result = dataclasses.replace(
-            result,
-            ef_search=ef,
-            search_time_us=search_time_us / NUM_QUERIES,
-            recall_rate=recall_rate,
-        )
-        benchmark_results.append(result)
-        plot_data_for_query[dim].append(PlotData(result.search_time_us, f"vectorlite_{distance_type}_ef_{ef}"))
-    cursor.execute(f"drop table {table_name}")
+    optional_descriptions = {
+        "sqlite_vss": "sqlite_vss (comparison)",
+        "sqlite_vec": "sqlite_vec (comparison)",
+        "milvus_lite": "milvus-lite (comparison)",
+    }
 
-for distance_type in distance_types:
-    for dim in DIMS:
-        for ef_construction, M in hnsw_params:
-            benchmark(distance_type, dim, ef_construction, M)
+    all_backends: List[Tuple[Backend, str]] = list(primary_backends)
+    for backend in collect_optional_backends(cursor, conn, data):
+        all_backends.append(
+            (backend, optional_descriptions.get(backend.name, backend.name)))
+
+    for backend, description in all_backends:
+        console.print(f"Benchmarking {description}.")
+        results = run_backend(backend, data, suite)
+        if results:
+            console.print(ResultTable(results))
+
+    suite.write_plots(NUM_ELEMENTS)
 
 
-result_table = ResultTable(benchmark_results)
-console.print(result_table)
-
-hnswlib_benchmark_results = []
-console.print("Bencharmk hnswlib as comparison.")
-def benchmark_hnswlib(distance_type, dim, ef_construction, M):
-    result = BenchmarkResult(distance_type, dim, ef_construction, M, 0, 0, 0, 0, "hnswlib")
-    hnswlib_index = hnswlib.Index(space=distance_type, dim=dim)
-    hnswlib_index.init_index(max_elements=NUM_ELEMENTS, ef_construction=ef_construction, M=M)
-
-    # measure insert time
-    insert_time_us, _ = timeit(
-        lambda: hnswlib_index.add_items(data[dim])
-    )
-    result.insert_time_us = insert_time_us / NUM_ELEMENTS
-    plot_data_for_insertion[dim].append(PlotData(result.insert_time_us, f"hnswlib_{distance_type}"))
-
-    for ef in efs:
-        hnswlib_index.set_ef(ef)
-        def search():
-            result = []
-            for i in range(NUM_QUERIES):
-                labels, distances = hnswlib_index.knn_query(query_data[dim][i], k=k)
-                result.append(labels)
-            return result
-
-        search_time_us, results = timeit(search)
-        recall_rate = np.mean(
-            [
-                np.intersect1d(results[i], correct_labels[distance_type][dim][i]).size
-                / k
-                for i in range(NUM_QUERIES)
-            ]
-        )
-        result = dataclasses.replace(
-            result,
-            ef_search=ef,
-            search_time_us=search_time_us / NUM_QUERIES,
-            recall_rate=recall_rate,
-        )
-        hnswlib_benchmark_results.append(result)
-        plot_data_for_query[dim].append(PlotData(result.search_time_us, f"hnswlib_{distance_type}_ef_{ef}"))
-    del hnswlib_index
-
-for distance_type in distance_types:
-    for dim in DIMS:
-        for ef_construction, M in hnsw_params:
-            benchmark_hnswlib(distance_type, dim, ef_construction, M)
-
-hnswlib_result_table = ResultTable(hnswlib_benchmark_results)
-console.print(hnswlib_result_table)
-
-brute_force_benchmark_results = []
-
-console.print("Bencharmk vectorlite brute force(select rowid from my_table order by vector_distance(query_vector, embedding, 'l2')) as comparison.")
-
-def benchmark_brute_force(dim: int):
-    benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite_brute_force")
-    table_name = f"table_vectorlite_bf_{dim}"
-    cursor.execute(
-        f"create table {table_name}(rowid integer primary key, embedding blob)"
-    )
-
-    insert_time_us, _ = timeit(
-        transactional(
-            lambda: cursor.executemany(
-                f"insert into {table_name}(rowid, embedding) values (?, ?)",
-                [(i, data_bytes[dim][i]) for i in range(NUM_ELEMENTS)],
-        ))
-    )
-    benchmark_result.insert_time_us = insert_time_us / NUM_ELEMENTS
-    plot_data_for_insertion[dim].append(PlotData(benchmark_result.insert_time_us, "vectorlite_scalar_brute_force"))
-
-    def search():
-        result = []
-        for i in range(NUM_QUERIES):
-            result.append(
-                cursor.execute(
-                    f"select rowid from {table_name} order by vector_distance(?, embedding, 'l2') asc limit {k}",
-                    [query_data_bytes[dim][i]],
-                ).fetchall()
-            )
-        return result
-
-    search_time_us, results = timeit(search)
-    # console.log(results)
-    benchmark_result.search_time_us = search_time_us / NUM_QUERIES
-    recall_rate = np.mean(
-        [
-            np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
-            for i in range(NUM_QUERIES)
-        ]
-    )
-    benchmark_result.recall_rate = recall_rate
-    brute_force_benchmark_results.append(benchmark_result)
-    plot_data_for_query[dim].append(PlotData(benchmark_result.search_time_us, "vectorlite_scalar_brute_force"))
-    cursor.execute(f"drop table {table_name}")
-
-for dim in DIMS:
-    benchmark_brute_force(dim)
-brute_force_table = ResultTable(brute_force_benchmark_results)
-console.print(brute_force_table)
-
-
-# Benchmark sqlite_vss as compariso.
-# pip install sqlite-vss
-import platform
-
-benchmark_vss = os.environ.get("BENCHMARK_VSS", "0") != "0"
-if benchmark_vss and (platform.system().lower() == "linux" or platform.system().lower() == "darwin"):
-    # note sqlite_vss is not self-contained.
-    # Need to install dependencies manually using: sudo apt-get install -y libgomp1 libatlas-base-dev liblapack-dev
-    console.print("Bencharmk sqlite_vss as comparison.")
-    import sqlite_vss
-
-    sqlite_vss.load(conn)
-
-    vss_benchmark_results = []
-
-    def benchmark_sqlite_vss(dim: int):
-        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
-        table_name = f"table_vss_{dim}"
-        cursor.execute(
-            f"create virtual table {table_name} using vss0(embedding({dim}))"
-        )
-
-        # measure insert time
-        insert_time_us, _ = timeit(
-            transactional(
-                lambda: cursor.executemany(
-                    f"insert into {table_name}(rowid, embedding) values (?, ?)",
-                    [(i, data_bytes[dim][i]) for i in range(NUM_ELEMENTS)],
-            ))
-        )
-        benchmark_result.insert_time_us = insert_time_us / NUM_ELEMENTS
-        # insertion for sqlite_vss is so slow that it makes other data points insignificant
-        plot_data_for_insertion[dim].append(PlotData(benchmark_result.insert_time_us, "sqlite_vss"))
-
-        def search():
-            result = []
-            for i in range(NUM_QUERIES):
-                result.append(
-                    cursor.execute(
-                        f"select rowid from {table_name} where vss_search(embedding, ?) limit {k}",
-                        (query_data_bytes[dim][i],),
-                    ).fetchall()
-                )
-            return result
-
-        search_time_us, results = timeit(search)
-        benchmark_result.search_time_us = search_time_us / NUM_QUERIES
-        recall_rate = np.mean(
-            [
-                np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
-                for i in range(NUM_QUERIES)
-            ]
-        )
-        benchmark_result.recall_rate = recall_rate
-        vss_benchmark_results.append(benchmark_result)
-        plot_data_for_query[dim].append(PlotData(benchmark_result.search_time_us, "sqlite_vss"))
-        cursor.execute(f"drop table {table_name}")
-
-    for dim in DIMS:
-        benchmark_sqlite_vss(dim)
-
-    vss_result_table = ResultTable(vss_benchmark_results)
-    console.print(vss_result_table)
-
-# benchmark sqlite-vec
-# pip install sqlite-vec
-benchmark_sqlite_vec = os.environ.get("BENCHMARK_SQLITE_VEC", "0") != "0"
-if benchmark_sqlite_vec and (platform.system().lower() == "linux" or platform.system().lower() == "darwin"):
-    # VssBenchamrkResult and VssResultTable can be reused
-    vec_benchmark_results = []
-    console.print("Bencharmk sqlite_vec as comparison.")
-    import sqlite_vec
-
-    conn.load_extension(sqlite_vec.loadable_path())
-
-    def benchmark_sqlite_vec(dim: int):
-        benchmark_result = BenchmarkResult("l2", dim, None, None, None, 0, 0, 0, "vectorLite")
-        table_name = f"table_vec_{dim}"
-        cursor.execute(
-            f"create virtual table {table_name} using vec0(rowid integer primary key, embedding float[{dim}])"
-        )
-
-        # measure insert time
-        insert_time_us, _ = timeit(
-            transactional(
-                lambda: cursor.executemany(
-                    f"insert into {table_name}(rowid, embedding) values (?, ?)",
-                    [(i, data_bytes[dim][i]) for i in range(NUM_ELEMENTS)],
-            ))
-        )
-        benchmark_result.insert_time_us = insert_time_us / NUM_ELEMENTS
-        plot_data_for_insertion[dim].append(PlotData(benchmark_result.insert_time_us, "sqlite_vec"))
-
-        def search():
-            result = []
-            for i in range(NUM_QUERIES):
-                result.append(
-                    cursor.execute(
-                        f"select rowid from {table_name} where embedding match ? and k = {k}",
-                        (query_data_bytes[dim][i],),
-                    ).fetchall()
-                )
-            return result
-
-        search_time_us, results = timeit(search)
-        benchmark_result.search_time_us = search_time_us / NUM_QUERIES
-        recall_rate = np.mean(
-            [
-                np.intersect1d(results[i], correct_labels["l2"][dim][i]).size / k
-                for i in range(NUM_QUERIES)
-            ]
-        )
-        benchmark_result.recall_rate = recall_rate
-        vec_benchmark_results.append(benchmark_result)
-        if NUM_ELEMENTS < 10000:
-            plot_data_for_query[dim].append(PlotData(benchmark_result.search_time_us, "sqlite_vec"))
-
-        cursor.execute(f"drop table {table_name}")
-
-    for dim in DIMS:
-        benchmark_sqlite_vec(dim)
-
-    vec_result_table = ResultTable(vec_benchmark_results)
-    console.print(vec_result_table)
-
-benchmark_milvus_lite = os.environ.get("BENCHMARK_MILVUS_LITE", "0") != "0"
-if benchmark_milvus_lite and (platform.system().lower() == "linux" or platform.system().lower() == "darwin"):
-    import os
-    from pymilvus import MilvusClient
-    import numpy as np
-
-    client = MilvusClient("./milvus_lite_demo.db")
-
-    def milvus_insert(client, collection_name, data):
-        client.insert(collection_name=collection_name, data=data)
-
-    def milvus_insert_many(client, collection_name, dim):
-        insert_data = [{"id": i, "embedding": data[dim][i].tolist()} for i in range(NUM_ELEMENTS)]
-        client.insert(collection_name=collection_name, data=insert_data)
-
-    def milvus_search(client, collection_name, distance_type, search_data):
-        res = client.search(
-            collection_name=collection_name,
-            data=[search_data],
-            search_params={"metric_type": distance_type.upper()}, # Search parameters
-        )
-        rowids = [result['id'] for result in res[0]]
-        return rowids
-
-    def milvus_create_table(client, collection_name, distance_type, dim):
-        from pymilvus import DataType
-
-        schema = client.create_schema(enable_dynamic_field=True)
-        schema.add_field("id", DataType.INT64, is_primary=True)
-        schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
-        index_params = client.prepare_index_params()
-
-        index_params.add_index(
-            field_name="embedding", 
-            metric_type=distance_type.upper(),
-        )
-        client.create_collection(
-            collection_name=collection_name,
-            schema=schema,
-            index_params=index_params,
-            dimension=dim  # The vectors we will use in this demo has 384 dimensions
-        )
-        
-        res = client.get_load_state(
-            collection_name=collection_name
-        )
-        # print(client.describe_index(collection_name,"embedding"))
-        # print(client.describe_index(collection_name,"id"))
-
-    console.print("Bencharmk milvuslite.")
-    benchmark_milvus_results = []
-    def benchmark_milvus(distance_type, dim):
-        result = BenchmarkResult(distance_type=distance_type, dim=dim, insert_time_us=0, search_time_us=0, recall_rate=0, product="milvusLite", ef_construction=None, M=None, ef_search=None)
-        collection_name = f"collection_{distance_type}_{dim}"
-
-        milvus_create_table(client=client, collection_name=collection_name, distance_type=distance_type, dim=dim)
-        
-        # measure insert time
-        insert_time_us, _ = timeit(
-            transactional(lambda: milvus_insert_many(client=client, collection_name=collection_name, dim=dim))
-        )
-
-        result.insert_time_us = insert_time_us / NUM_ELEMENTS
-        plot_data_for_insertion[dim].append(PlotData(result.insert_time_us, f"milvuslite_{distance_type}"))
-
-
-        def search():
-            result = []
-            for i in range(NUM_QUERIES):
-                result.append(
-                    milvus_search(client=client, collection_name=collection_name, distance_type=distance_type, search_data=query_data_for_milvus[dim][i])
-                )
-            return result
-
-        search_time_us, results = timeit(search)
-        # console.log(results)
-        recall_rate = np.mean(
-            [
-                np.intersect1d(results[i], correct_labels[distance_type][dim][i]).size
-                / k
-                for i in range(NUM_QUERIES)
-            ]
-        )
-        result = dataclasses.replace(
-            result,
-            search_time_us=search_time_us / NUM_QUERIES,
-            recall_rate=recall_rate,
-        )
-
-        benchmark_milvus_results.append(result)
-        plot_data_for_query[dim].append(PlotData(result.search_time_us, f"milvuslite_{distance_type}"))
-        client.drop_collection(collection_name=collection_name)
-
-    for distance_type in distance_types:
-        for dim in DIMS:
-            benchmark_milvus(distance_type, dim)
-
-    console.print(ResultTable(benchmark_milvus_results))
-
-import plot
-def plot_figures():
-    vector_insertion_columns = ["dim"] + [plot_data.column for plot_data in plot_data_for_insertion[DIMS[0]]]
-    vector_insertion_data = [[dim] + [plot_data.time_taken_us for plot_data in plot_data_for_insertion[dim]] for dim in DIMS]
-    plot.plot(f"vector_insertion_{NUM_ELEMENTS}_vectors", vector_insertion_columns, vector_insertion_data)
-
-    vector_query_columns = ["dim"] + [plot_data.column for plot_data in plot_data_for_query[DIMS[0]]]
-    vector_query_data = [[dim] + [plot_data.time_taken_us for plot_data in plot_data_for_query[dim]] for dim in DIMS]
-    plot.plot(f"vector_query_{NUM_ELEMENTS}_vectors", vector_query_columns, vector_query_data)
-
-plot_figures()
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -196,9 +196,14 @@ class _SqlBackend(Backend):
         rows = [(i, self.data.data_bytes[self._dim][i])
                 for i in range(self.data.num_elements)]
         self.cursor.execute("BEGIN TRANSACTION;")
-        self.cursor.executemany(
-            f"insert into {self._table}(rowid, embedding) values (?, ?)", rows)
-        self.cursor.execute("COMMIT;")
+        try:
+            self.cursor.executemany(
+                f"insert into {self._table}(rowid, embedding) values (?, ?)",
+                rows)
+            self.cursor.execute("COMMIT;")
+        except Exception:
+            self.cursor.execute("ROLLBACK;")
+            raise
 
     def teardown(self) -> None:
         if self._table is not None:
@@ -409,6 +414,7 @@ class MilvusLiteBackend(Backend):
                 collection_name=self._collection,
                 data=[self.data.queries[dim][i].tolist()],
                 search_params={"metric_type": distance_type.upper()},
+                limit=K,
             )
             results.append([hit["id"] for hit in response[0]])
         return results

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -15,6 +15,8 @@ Configuration is driven by environment variables (read by ``conftest.py``):
     BENCHMARK_VSS=1        enable sqlite_vss backend (Linux/macOS only)
     BENCHMARK_SQLITE_VEC=1 enable sqlite-vec backend (Linux/macOS only)
     BENCHMARK_MILVUS_LITE=1 enable milvus-lite backend (Linux/macOS only)
+    BENCHMARK_LIBSQL=1     enable libSQL backend (Linux/macOS only)
+    BENCHMARK_SQLITE_VECTOR=1 enable sqlite-vector backend (Linux/macOS only)
 
 SQLite driver
 -------------
@@ -423,3 +425,95 @@ class MilvusLiteBackend(Backend):
         if self._collection is not None:
             self._client.drop_collection(collection_name=self._collection)
             self._collection = None
+
+
+class LibSQLBackend(Backend):
+    """libSQL (Turso) with built-in DiskANN vector index."""
+
+    name = "libsql"
+    plot_label = "libsql_{distance_type}{ef_search}"
+
+    def __init__(self, data: BenchmarkData) -> None:
+        import libsql_experimental
+        self.data = data
+        self._conn = libsql_experimental.connect(":memory:")
+        self._cursor = self._conn.cursor()
+        self._table: Optional[str] = None
+        self._index: Optional[str] = None
+        self._dim: int = 0
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        self._table = f"t_libsql_{distance_type}_{dim}"
+        self._index = f"idx_libsql_{distance_type}_{dim}"
+        self._cursor.execute(
+            f"CREATE TABLE {self._table} ("
+            f"rowid INTEGER PRIMARY KEY, "
+            f"embedding F32_BLOB({dim}))")
+        self._conn.commit()
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        rows = [(i, self.data.data_bytes[dim][i])
+                for i in range(self.data.num_elements)]
+        self._cursor.executemany(
+            f"INSERT INTO {self._table} (rowid, embedding) VALUES (?, ?)",
+            rows)
+        self._conn.commit()
+        # Build DiskANN index after bulk insert.
+        self._cursor.execute(
+            f"CREATE INDEX {self._index} ON {self._table} "
+            f"(libsql_vector_idx(embedding, 'metric={distance_type}'))")
+        self._conn.commit()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            rows = self._cursor.execute(
+                f"SELECT id FROM vector_top_k('{self._index}', ?, ?)",
+                (self.data.query_bytes[dim][i], K),
+            ).fetchall()
+            results.append([row[0] for row in rows])
+        return results
+
+    def teardown(self) -> None:
+        if self._table is not None:
+            self._cursor.execute(f"DROP TABLE IF EXISTS {self._table}")
+            self._conn.commit()
+            self._table = None
+            self._index = None
+
+
+class SqliteVectorBackend(_SqlBackend):
+    """sqlite-vector (sqliteai) SIMD-accelerated full scan."""
+
+    name = "sqlite_vector"
+    plot_label = "sqlite_vector_{distance_type}"
+
+    def setup(self, distance_type: str, dim: int,
+              ef_construction: Optional[int], M: Optional[int]) -> None:
+        self._dim = dim
+        dist = "L2" if distance_type == "l2" else "COSINE"
+        self._table = f"table_sqlite_vector_{distance_type}_{dim}"
+        self.cursor.execute(
+            f"CREATE TABLE {self._table}"
+            f"(rowid INTEGER PRIMARY KEY, embedding BLOB)")
+        self.cursor.execute(
+            f"SELECT vector_init('{self._table}', 'embedding', "
+            f"'dimension={dim},type=FLOAT32,distance={dist}')")
+
+    def do_insert(self, distance_type: str, dim: int) -> None:
+        self._insert_rows()
+
+    def do_search(self, distance_type: str, dim: int,
+                  ef_search: Optional[int]) -> List[Sequence[int]]:
+        results = []
+        for i in range(NUM_QUERIES):
+            rows = self.cursor.execute(
+                f"SELECT rowid FROM vector_full_scan("
+                f"'{self._table}', 'embedding', ?, {K})",
+                (self.data.query_bytes[dim][i],),
+            ).fetchall()
+            results.append(rows)
+        return results

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -485,35 +485,69 @@ class LibSQLBackend(Backend):
             self._index = None
 
 
-class SqliteVectorBackend(_SqlBackend):
-    """sqlite-vector (sqliteai) SIMD-accelerated full scan."""
+class SqliteVectorBackend(Backend):
+    """sqlite-vector (sqliteai) SIMD-accelerated full scan.
+
+    Uses its own sqlite3 connection to avoid conflicts with other loaded
+    extensions (e.g. sqlite-vss registers overlapping function names).
+    """
 
     name = "sqlite_vector"
     plot_label = "sqlite_vector_{distance_type}"
+
+    def __init__(self, data: BenchmarkData,
+                 vectorlite_path: Optional[str] = None) -> None:
+        import importlib.resources
+        self.data = data
+        self._conn = sqlite3.connect(":memory:", isolation_level=None)
+        self._conn.enable_load_extension(True)
+        if vectorlite_path is not None:
+            self._conn.load_extension(vectorlite_path)
+        ext_path = str(
+            importlib.resources.files("sqlite_vector.binaries") / "vector")
+        self._conn.load_extension(ext_path)
+        self._cursor = self._conn.cursor()
+        self._table: Optional[str] = None
+        self._dim: int = 0
 
     def setup(self, distance_type: str, dim: int,
               ef_construction: Optional[int], M: Optional[int]) -> None:
         self._dim = dim
         dist = "L2" if distance_type == "l2" else "COSINE"
         self._table = f"table_sqlite_vector_{distance_type}_{dim}"
-        self.cursor.execute(
+        self._cursor.execute(
             f"CREATE TABLE {self._table}"
             f"(rowid INTEGER PRIMARY KEY, embedding BLOB)")
-        self.cursor.execute(
+        self._cursor.execute(
             f"SELECT vector_init('{self._table}', 'embedding', "
             f"'dimension={dim},type=FLOAT32,distance={dist}')")
 
     def do_insert(self, distance_type: str, dim: int) -> None:
-        self._insert_rows()
+        rows = [(i, self.data.data_bytes[self._dim][i])
+                for i in range(self.data.num_elements)]
+        self._cursor.execute("BEGIN TRANSACTION;")
+        try:
+            self._cursor.executemany(
+                f"INSERT INTO {self._table}(rowid, embedding) VALUES (?, ?)",
+                rows)
+            self._cursor.execute("COMMIT;")
+        except Exception:
+            self._cursor.execute("ROLLBACK;")
+            raise
 
     def do_search(self, distance_type: str, dim: int,
                   ef_search: Optional[int]) -> List[Sequence[int]]:
         results = []
         for i in range(NUM_QUERIES):
-            rows = self.cursor.execute(
+            rows = self._cursor.execute(
                 f"SELECT rowid FROM vector_full_scan("
                 f"'{self._table}', 'embedding', ?, {K})",
                 (self.data.query_bytes[dim][i],),
             ).fetchall()
             results.append(rows)
         return results
+
+    def teardown(self) -> None:
+        if self._table is not None:
+            self._cursor.execute(f"DROP TABLE {self._table}")
+            self._table = None

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -10,6 +10,23 @@ Configuration is driven by environment variables:
     BENCHMARK_VSS=1        also benchmark sqlite_vss (Linux/macOS only)
     BENCHMARK_SQLITE_VEC=1 also benchmark sqlite-vec (Linux/macOS only)
     BENCHMARK_MILVUS_LITE=1 also benchmark milvus-lite (Linux/macOS only)
+
+SQLite driver
+-------------
+
+The benchmark uses Python's standard-library ``sqlite3`` module rather than
+``apsw``. The module loads the vectorlite extension via
+``conn.enable_load_extension(True)`` followed by ``conn.load_extension(...)``,
+which requires a Python interpreter built with
+``--enable-loadable-sqlite-extensions``. Standard Homebrew, python.org and
+modern Linux distribution Python builds all enable this; if your interpreter
+does not, ``conn.enable_load_extension(True)`` raises ``AttributeError`` or
+``OperationalError`` and you will need a different Python build (or ``apsw``).
+
+Vectorlite's optional metadata-filter (rowid pushdown) feature requires
+SQLite >= 3.38; the benchmark itself does not exercise that path, so any
+SQLite version that vectorlite loads on will work here. The bundled SQLite
+version is reported by ``sqlite3.sqlite_version``.
 """
 
 from __future__ import annotations
@@ -17,11 +34,11 @@ from __future__ import annotations
 import dataclasses
 import os
 import platform
+import sqlite3
 import time
 from collections import defaultdict
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 
-import apsw
 import hnswlib
 import numpy as np
 import vectorlite_py
@@ -235,9 +252,9 @@ class Backend:
 
 
 class _SqlBackend(Backend):
-    """Shared scaffolding for backends that use the apsw cursor."""
+    """Shared scaffolding for backends that use the sqlite3 cursor."""
 
-    def __init__(self, cursor: apsw.Cursor, data: BenchmarkData) -> None:
+    def __init__(self, cursor: sqlite3.Cursor, data: BenchmarkData) -> None:
         self.cursor = cursor
         self.data = data
         self._table: Optional[str] = None
@@ -579,7 +596,7 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "0") != "0"
 
 
-def collect_optional_backends(cursor: apsw.Cursor, conn: apsw.Connection,
+def collect_optional_backends(cursor: sqlite3.Cursor, conn: sqlite3.Connection,
                               data: BenchmarkData) -> List[Backend]:
     backends: List[Backend] = []
     if not is_supported_platform():
@@ -614,7 +631,11 @@ def main() -> None:
     if vectorlite_path != vectorlite_py.vectorlite_path():
         console.print(f"Using local vectorlite: {vectorlite_path}")
 
-    conn = apsw.Connection(":memory:")
+    # ``isolation_level=None`` puts sqlite3 in autocommit mode so that the
+    # explicit ``BEGIN TRANSACTION`` / ``COMMIT`` statements issued by
+    # ``_SqlBackend._insert_rows`` are honoured rather than wrapped in an
+    # implicit transaction by the driver.
+    conn = sqlite3.connect(":memory:", isolation_level=None)
     conn.enable_load_extension(True)
     conn.load_extension(vectorlite_path)
     cursor = conn.cursor()

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,57 +1,53 @@
-"""Benchmark vectorlite's performance and recall against alternative backends.
+"""Benchmark harness library: synthetic data, ground truth, and pluggable backends.
+
+This module is consumed by ``test_benchmark.py``. Run the benchmarks with::
+
+    pytest benchmark/test_benchmark.py --benchmark-json=bench.json
+    python benchmark/plot.py bench.json
 
 Methodology follows
 https://github.com/nmslib/hnswlib/blob/v0.8.0/TESTING_RECALL.md.
 
-Configuration is driven by environment variables:
+Configuration is driven by environment variables (read by ``conftest.py``):
 
     NUM_ELEMENTS           number of random vectors to index (default 3000)
     VECTORLITE_PATH        path to a locally built vectorlite extension
-    BENCHMARK_VSS=1        also benchmark sqlite_vss (Linux/macOS only)
-    BENCHMARK_SQLITE_VEC=1 also benchmark sqlite-vec (Linux/macOS only)
-    BENCHMARK_MILVUS_LITE=1 also benchmark milvus-lite (Linux/macOS only)
+    BENCHMARK_VSS=1        enable sqlite_vss backend (Linux/macOS only)
+    BENCHMARK_SQLITE_VEC=1 enable sqlite-vec backend (Linux/macOS only)
+    BENCHMARK_MILVUS_LITE=1 enable milvus-lite backend (Linux/macOS only)
 
 SQLite driver
 -------------
 
 The benchmark uses Python's standard-library ``sqlite3`` module rather than
-``apsw``. The module loads the vectorlite extension via
-``conn.enable_load_extension(True)`` followed by ``conn.load_extension(...)``,
-which requires a Python interpreter built with
-``--enable-loadable-sqlite-extensions``. Standard Homebrew, python.org and
-modern Linux distribution Python builds all enable this; if your interpreter
-does not, ``conn.enable_load_extension(True)`` raises ``AttributeError`` or
-``OperationalError`` and you will need a different Python build (or ``apsw``).
+``apsw``. Loading the vectorlite extension via ``conn.load_extension(...)``
+requires a Python interpreter built with
+``--enable-loadable-sqlite-extensions`` (standard on Homebrew, python.org
+and modern Linux distribution Python builds). If your interpreter does not
+enable that, ``conn.enable_load_extension(True)`` raises ``AttributeError``
+or ``OperationalError`` and you will need a different Python build (or
+``apsw``).
 
-Vectorlite's optional metadata-filter (rowid pushdown) feature requires
+Vectorlite's metadata-filter (rowid pushdown) feature requires
 SQLite >= 3.38; the benchmark itself does not exercise that path, so any
-SQLite version that vectorlite loads on will work here. The bundled SQLite
+SQLite version that vectorlite loads on will work. The bundled SQLite
 version is reported by ``sqlite3.sqlite_version``.
 """
 
 from __future__ import annotations
 
 import dataclasses
-import os
 import platform
 import sqlite3
-import time
-from collections import defaultdict
-from typing import Callable, Iterable, List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import hnswlib
 import numpy as np
-import vectorlite_py
-from rich.console import Console, ConsoleOptions, RenderResult
-from rich.table import Table
-
-import plot
 
 # ---------------------------------------------------------------------------
-# Configuration
+# Configuration constants
 # ---------------------------------------------------------------------------
 
-NUM_ELEMENTS: int = int(os.environ.get("NUM_ELEMENTS", 3000))
 NUM_QUERIES: int = 100
 K: int = 10  # number of nearest neighbours retrieved per query
 
@@ -61,23 +57,10 @@ DISTANCE_TYPES: List[str] = ["l2", "cosine"]
 HNSW_PARAMS: List[Tuple[int, int]] = [(100, 30)]  # (ef_construction, M)
 EF_SEARCH_VALUES: List[int] = [10, 50, 100]
 
-console = Console()
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def timeit(func: Callable[[], object]) -> Tuple[float, object]:
-    """Run ``func`` once. Return (elapsed_microseconds, return_value).
-
-    Avoids ``timeit.timeit`` which compiles strings and discards return values.
-    """
-    start_us = time.perf_counter_ns() / 1000
-    retval = func()
-    end_us = time.perf_counter_ns() / 1000
-    return end_us - start_us, retval
 
 
 def compute_recall(predicted: Sequence[Sequence[int]],
@@ -102,8 +85,9 @@ def is_supported_platform() -> bool:
 class BenchmarkData:
     """Random vectors plus their precomputed brute-force k-NN ground truth."""
 
+    num_elements: int
     data: dict          # dim -> np.ndarray (NUM_ELEMENTS x dim, float32)
-    data_bytes: dict    # dim -> list[bytes]   (one per element, for SQL inserts)
+    data_bytes: dict    # dim -> list[bytes] (one per element, for SQL inserts)
     queries: dict       # dim -> np.ndarray (NUM_QUERIES x dim, float32)
     query_bytes: dict   # dim -> list[bytes]
     correct_labels: dict  # distance_type -> dim -> np.ndarray (NUM_QUERIES x K)
@@ -135,65 +119,8 @@ class BenchmarkData:
                 correct_labels[dt][d] = labels
                 del bf
 
-        return cls(data, data_bytes, queries, query_bytes, correct_labels)
-
-
-# ---------------------------------------------------------------------------
-# Result containers
-# ---------------------------------------------------------------------------
-
-
-@dataclasses.dataclass
-class BenchmarkResult:
-    product: str
-    distance_type: str
-    dim: int
-    insert_time_us: float
-    search_time_us: float
-    recall_rate: float
-    ef_construction: Optional[int] = None
-    M: Optional[int] = None
-    ef_search: Optional[int] = None
-
-
-@dataclasses.dataclass
-class ResultTable:
-    """Render a list of ``BenchmarkResult`` as a rich Table."""
-
-    results: List[BenchmarkResult]
-
-    def __rich_console__(self, console: Console,
-                         options: ConsoleOptions) -> RenderResult:
-        if not self.results:
-            yield Table()
-            return
-
-        show_hnsw = self.results[0].ef_construction is not None
-
-        table = Table()
-        table.add_column("product\nname")
-        table.add_column("distance\ntype")
-        table.add_column("vector\ndimension")
-        if show_hnsw:
-            table.add_column("ef\nconstruction")
-            table.add_column("M")
-            table.add_column("ef\nsearch")
-        table.add_column("insert_time\nper vector")
-        table.add_column("search_time\nper query")
-        table.add_column("recall\nrate")
-
-        for r in self.results:
-            row = [r.product, r.distance_type, str(r.dim)]
-            if show_hnsw:
-                row += [str(r.ef_construction), str(r.M), str(r.ef_search)]
-            row += [
-                f"{r.insert_time_us:.2f} us",
-                f"{r.search_time_us:.2f} us",
-                f"{r.recall_rate * 100:.2f}%",
-            ]
-            table.add_row(*row)
-
-        yield table
+        return cls(num_elements, data, data_bytes,
+                   queries, query_bytes, correct_labels)
 
 
 # ---------------------------------------------------------------------------
@@ -205,8 +132,13 @@ class Backend:
     """Common interface for every system under test.
 
     A backend handles the lifecycle of one (distance_type, dim, hnsw_params)
-    configuration. ``run_backend`` drives it end to end; the backend just
-    declares its capabilities and implements the four lifecycle hooks.
+    configuration. ``test_benchmark.py`` drives it through:
+
+        backend.setup(distance_type, dim, ef_construction, M)
+        backend.do_insert(distance_type, dim)              # measured
+        for ef in EF_SEARCH_VALUES (or [None]):
+            backend.do_search(distance_type, dim, ef)      # measured
+        backend.teardown()
     """
 
     name: str = "<unknown>"
@@ -258,10 +190,11 @@ class _SqlBackend(Backend):
         self.cursor = cursor
         self.data = data
         self._table: Optional[str] = None
+        self._dim: int = 0
 
     def _insert_rows(self) -> None:
         rows = [(i, self.data.data_bytes[self._dim][i])
-                for i in range(NUM_ELEMENTS)]
+                for i in range(self.data.num_elements)]
         self.cursor.execute("BEGIN TRANSACTION;")
         self.cursor.executemany(
             f"insert into {self._table}(rowid, embedding) values (?, ?)", rows)
@@ -286,7 +219,7 @@ class VectorliteBackend(_SqlBackend):
         self.cursor.execute(
             f"create virtual table {self._table} using vectorlite("
             f"embedding float32[{dim}] {distance_type}, "
-            f"hnsw(max_elements={NUM_ELEMENTS}, "
+            f"hnsw(max_elements={self.data.num_elements}, "
             f"ef_construction={ef_construction}, M={M}))"
         )
 
@@ -348,7 +281,7 @@ class HnswlibBackend(Backend):
               ef_construction: Optional[int], M: Optional[int]) -> None:
         self._index = hnswlib.Index(space=distance_type, dim=dim)
         self._index.init_index(
-            max_elements=NUM_ELEMENTS,
+            max_elements=self.data.num_elements,
             ef_construction=ef_construction,
             M=M,
         )
@@ -428,17 +361,13 @@ class SqliteVecBackend(_SqlBackend):
             ).fetchall())
         return results
 
-    @property
-    def include_in_query_plot(self) -> bool:  # type: ignore[override]
-        # sqlite-vec's brute force search dominates the plot at high N.
-        return NUM_ELEMENTS < 10000
-
 
 class MilvusLiteBackend(Backend):
     name = "milvus_lite"
     plot_label = "milvuslite_{distance_type}{ef_search}"
 
-    def __init__(self, data: BenchmarkData, db_path: str = "./milvus_lite_demo.db") -> None:
+    def __init__(self, data: BenchmarkData,
+                 db_path: str = "./milvus_lite_demo.db") -> None:
         from pymilvus import MilvusClient
         self.data = data
         self._client = MilvusClient(db_path)
@@ -468,7 +397,7 @@ class MilvusLiteBackend(Backend):
     def do_insert(self, distance_type: str, dim: int) -> None:
         rows = [
             {"id": i, "embedding": self.data.data[dim][i].tolist()}
-            for i in range(NUM_ELEMENTS)
+            for i in range(self.data.num_elements)
         ]
         self._client.insert(collection_name=self._collection, data=rows)
 
@@ -488,198 +417,3 @@ class MilvusLiteBackend(Backend):
         if self._collection is not None:
             self._client.drop_collection(collection_name=self._collection)
             self._collection = None
-
-
-# ---------------------------------------------------------------------------
-# Benchmark runner
-# ---------------------------------------------------------------------------
-
-
-@dataclasses.dataclass
-class PlotData:
-    time_taken_us: float
-    column: str
-
-
-@dataclasses.dataclass
-class BenchmarkSuite:
-    """Accumulates results and per-dim plot points across backends."""
-
-    plot_insertion: dict = dataclasses.field(default_factory=lambda: defaultdict(list))
-    plot_query: dict = dataclasses.field(default_factory=lambda: defaultdict(list))
-
-    def record_insertion(self, dim: int, label: str, time_us: float) -> None:
-        self.plot_insertion[dim].append(PlotData(time_us, label))
-
-    def record_query(self, dim: int, label: str, time_us: float) -> None:
-        self.plot_query[dim].append(PlotData(time_us, label))
-
-    def write_plots(self, num_elements: int) -> None:
-        for kind, points in (("insertion", self.plot_insertion),
-                             ("query", self.plot_query)):
-            if not points:
-                continue
-            dims = sorted(points.keys())
-            columns = ["dim"] + [p.column for p in points[dims[0]]]
-            rows = [[d] + [p.time_taken_us for p in points[d]] for d in dims]
-            plot.plot(f"vector_{kind}_{num_elements}_vectors", columns, rows)
-
-
-def run_backend(backend: Backend, data: BenchmarkData,
-                suite: BenchmarkSuite,
-                distance_types: Sequence[str] = DISTANCE_TYPES,
-                dims: Sequence[int] = DIMS,
-                hnsw_params: Sequence[Tuple[int, int]] = HNSW_PARAMS,
-                ef_values: Sequence[int] = EF_SEARCH_VALUES,
-                ) -> List[BenchmarkResult]:
-    """Run one backend across all configurations; return its results."""
-    param_combos: Iterable[Tuple[Optional[int], Optional[int]]] = (
-        hnsw_params if backend.uses_hnsw_params else [(None, None)]
-    )
-    ef_iter: Sequence[Optional[int]] = (
-        ef_values if backend.supports_ef_search else [None]
-    )
-    relevant_distances = [
-        d for d in distance_types if d in backend.supported_distances
-    ]
-
-    results: List[BenchmarkResult] = []
-
-    for distance_type in relevant_distances:
-        for dim in dims:
-            for ef_construction, M in param_combos:
-                backend.setup(distance_type, dim, ef_construction, M)
-                try:
-                    insert_total_us, _ = timeit(
-                        lambda: backend.do_insert(distance_type, dim))
-                    insert_time_us = insert_total_us / NUM_ELEMENTS
-                    suite.record_insertion(
-                        dim, backend.insertion_label(distance_type),
-                        insert_time_us)
-
-                    for ef in ef_iter:
-                        search_total_us, query_results = timeit(
-                            lambda: backend.do_search(distance_type, dim, ef))
-                        search_time_us = search_total_us / NUM_QUERIES
-                        recall = compute_recall(
-                            query_results,
-                            data.correct_labels[distance_type][dim], K)
-
-                        results.append(BenchmarkResult(
-                            product=backend.name,
-                            distance_type=distance_type,
-                            dim=dim,
-                            insert_time_us=insert_time_us,
-                            search_time_us=search_time_us,
-                            recall_rate=recall,
-                            ef_construction=ef_construction,
-                            M=M,
-                            ef_search=ef,
-                        ))
-                        if backend.include_in_query_plot:
-                            suite.record_query(
-                                dim,
-                                backend.query_label(distance_type, ef),
-                                search_time_us)
-                finally:
-                    backend.teardown()
-
-    return results
-
-
-# ---------------------------------------------------------------------------
-# Optional backend loaders (gated by env vars / platform)
-# ---------------------------------------------------------------------------
-
-
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "0") != "0"
-
-
-def collect_optional_backends(cursor: sqlite3.Cursor, conn: sqlite3.Connection,
-                              data: BenchmarkData) -> List[Backend]:
-    backends: List[Backend] = []
-    if not is_supported_platform():
-        return backends
-
-    if _env_flag("BENCHMARK_VSS"):
-        # sqlite_vss is not self-contained; on Debian/Ubuntu install:
-        #   sudo apt-get install -y libgomp1 libatlas-base-dev liblapack-dev
-        import sqlite_vss
-        sqlite_vss.load(conn)
-        backends.append(SqliteVssBackend(cursor, data))
-
-    if _env_flag("BENCHMARK_SQLITE_VEC"):
-        import sqlite_vec
-        conn.load_extension(sqlite_vec.loadable_path())
-        backends.append(SqliteVecBackend(cursor, data))
-
-    if _env_flag("BENCHMARK_MILVUS_LITE"):
-        backends.append(MilvusLiteBackend(data))
-
-    return backends
-
-
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
-
-
-def main() -> None:
-    vectorlite_path = os.environ.get(
-        "VECTORLITE_PATH", vectorlite_py.vectorlite_path())
-    if vectorlite_path != vectorlite_py.vectorlite_path():
-        console.print(f"Using local vectorlite: {vectorlite_path}")
-
-    # ``isolation_level=None`` puts sqlite3 in autocommit mode so that the
-    # explicit ``BEGIN TRANSACTION`` / ``COMMIT`` statements issued by
-    # ``_SqlBackend._insert_rows`` are honoured rather than wrapped in an
-    # implicit transaction by the driver.
-    conn = sqlite3.connect(":memory:", isolation_level=None)
-    conn.enable_load_extension(True)
-    conn.load_extension(vectorlite_path)
-    cursor = conn.cursor()
-
-    console.print(
-        f"Benchmarking with {NUM_ELEMENTS} random vectors. "
-        f"{NUM_QUERIES} {K}-nearest-neighbour queries per case."
-    )
-
-    data = BenchmarkData.generate(
-        DIMS, NUM_ELEMENTS, NUM_QUERIES, K, DISTANCE_TYPES)
-
-    suite = BenchmarkSuite()
-
-    # The order here defines column order in plot CSV / PNG output.
-    primary_backends: List[Tuple[Backend, str]] = [
-        (VectorliteBackend(cursor, data),
-         "vectorlite (HNSW virtual table)"),
-        (HnswlibBackend(data),
-         "hnswlib (in-memory, comparison)"),
-        (VectorliteBruteForceBackend(cursor, data),
-         "vectorlite brute force "
-         "(SELECT ... ORDER BY vector_distance(...))"),
-    ]
-
-    optional_descriptions = {
-        "sqlite_vss": "sqlite_vss (comparison)",
-        "sqlite_vec": "sqlite_vec (comparison)",
-        "milvus_lite": "milvus-lite (comparison)",
-    }
-
-    all_backends: List[Tuple[Backend, str]] = list(primary_backends)
-    for backend in collect_optional_backends(cursor, conn, data):
-        all_backends.append(
-            (backend, optional_descriptions.get(backend.name, backend.name)))
-
-    for backend, description in all_backends:
-        console.print(f"Benchmarking {description}.")
-        results = run_backend(backend, data, suite)
-        if results:
-            console.print(ResultTable(results))
-
-    suite.write_plots(NUM_ELEMENTS)
-
-
-if __name__ == "__main__":
-    main()

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -192,12 +192,6 @@ def sqlite_conn(vectorlite_path: str) -> Iterator[sqlite3.Connection]:
         import sqlite_vec
         conn.load_extension(sqlite_vec.loadable_path())
 
-    if _env_flag("BENCHMARK_SQLITE_VECTOR") and is_supported_platform():
-        import importlib.resources
-        ext_path = str(
-            importlib.resources.files("sqlite_vector.binaries") / "vector")
-        conn.load_extension(ext_path)
-
     try:
         yield conn
     finally:
@@ -282,11 +276,11 @@ def libsql_backend(benchmark_data) -> LibSQLBackend:
 
 
 @pytest.fixture
-def sqlite_vector_backend(sqlite_cursor,
+def sqlite_vector_backend(vectorlite_path,
                           benchmark_data) -> SqliteVectorBackend:
     if not _env_flag("BENCHMARK_SQLITE_VECTOR"):
         pytest.skip(
             "set BENCHMARK_SQLITE_VECTOR=1 to enable sqlite-vector benchmark")
     if not is_supported_platform():
         pytest.skip("sqlite-vector only supported on Linux/macOS")
-    return SqliteVectorBackend(sqlite_cursor, benchmark_data)
+    return SqliteVectorBackend(benchmark_data, vectorlite_path=vectorlite_path)

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -52,9 +52,11 @@ from benchmark import (
     DISTANCE_TYPES,
     HnswlibBackend,
     K,
+    LibSQLBackend,
     MilvusLiteBackend,
     NUM_QUERIES,
     SqliteVecBackend,
+    SqliteVectorBackend,
     SqliteVssBackend,
     VectorliteBackend,
     VectorliteBruteForceBackend,
@@ -190,6 +192,12 @@ def sqlite_conn(vectorlite_path: str) -> Iterator[sqlite3.Connection]:
         import sqlite_vec
         conn.load_extension(sqlite_vec.loadable_path())
 
+    if _env_flag("BENCHMARK_SQLITE_VECTOR") and is_supported_platform():
+        import importlib.resources
+        ext_path = str(
+            importlib.resources.files("sqlite_vector.binaries") / "vector")
+        conn.load_extension(ext_path)
+
     try:
         yield conn
     finally:
@@ -262,3 +270,23 @@ def milvus_lite_backend(benchmark_data) -> MilvusLiteBackend:
     if not is_supported_platform():
         pytest.skip("milvus-lite only supported on Linux/macOS")
     return MilvusLiteBackend(benchmark_data)
+
+
+@pytest.fixture
+def libsql_backend(benchmark_data) -> LibSQLBackend:
+    if not _env_flag("BENCHMARK_LIBSQL"):
+        pytest.skip("set BENCHMARK_LIBSQL=1 to enable libSQL benchmark")
+    if not is_supported_platform():
+        pytest.skip("libSQL only supported on Linux/macOS")
+    return LibSQLBackend(benchmark_data)
+
+
+@pytest.fixture
+def sqlite_vector_backend(sqlite_cursor,
+                          benchmark_data) -> SqliteVectorBackend:
+    if not _env_flag("BENCHMARK_SQLITE_VECTOR"):
+        pytest.skip(
+            "set BENCHMARK_SQLITE_VECTOR=1 to enable sqlite-vector benchmark")
+    if not is_supported_platform():
+        pytest.skip("sqlite-vector only supported on Linux/macOS")
+    return SqliteVectorBackend(sqlite_cursor, benchmark_data)

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -4,12 +4,29 @@ Provides session-scoped, expensive resources (extension-loaded sqlite
 connection, randomly generated test data, ground-truth labels) plus
 ``backend_factory`` fixtures that hand out fresh ``Backend`` instances to
 each test.
+
+Selecting the vectorlite library to benchmark
+---------------------------------------------
+
+Resolution order:
+
+1. ``--vectorlite-path=<path>`` command-line option (highest priority)
+2. ``VECTORLITE_PATH`` environment variable
+3. ``vectorlite_py.vectorlite_path()`` from the installed wheel (fallback)
+
+The session prints which file was loaded and its size; if the resolved
+path looks like a debug build (path contains ``/build/dev/``,
+``/Debug/`` or ``/debug/``) a warning is emitted because debug builds
+are typically several times slower than release.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import sqlite3
+import warnings
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -40,6 +57,77 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "0") != "0"
 
 
+_DEBUG_PATH_RE = re.compile(r"(/build/dev/|/Debug/|/debug/)")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("vectorlite", "vectorlite benchmark options")
+    group.addoption(
+        "--vectorlite-path",
+        action="store",
+        default=None,
+        help="Path to the vectorlite shared library to benchmark. "
+             "Overrides the VECTORLITE_PATH environment variable. "
+             "Defaults to the wheel's bundled binary.",
+    )
+
+
+def _resolve_vectorlite_path(config: pytest.Config) -> str:
+    cli = config.getoption("--vectorlite-path")
+    if cli:
+        return os.path.abspath(cli)
+    env = os.environ.get("VECTORLITE_PATH")
+    if env:
+        return os.path.abspath(env)
+    return vectorlite_py.vectorlite_path()
+
+
+@pytest.fixture(scope="session")
+def vectorlite_path(pytestconfig: pytest.Config) -> str:
+    return _resolve_vectorlite_path(pytestconfig)
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    """Print the resolved vectorlite library banner above the test list."""
+    path = _resolve_vectorlite_path(config)
+
+    # ``vectorlite_py.vectorlite_path()`` and the VECTORLITE_PATH convention
+    # may omit the platform-specific suffix (SQLite's loader appends it).
+    # Look for the actual file on disk so we can print its size.
+    resolved = Path(path)
+    if not resolved.exists():
+        for ext in (".dylib", ".so", ".dll"):
+            candidate = resolved.with_suffix(ext) if resolved.suffix else \
+                Path(str(resolved) + ext)
+            if candidate.exists():
+                resolved = candidate
+                break
+
+    try:
+        size_bytes = resolved.stat().st_size
+        size_str = f"{size_bytes / (1024 * 1024):.2f} MiB"
+    except OSError:
+        size_str = "missing"
+
+    lines = [
+        f"vectorlite: {path}",
+        f"            ({size_str}, sqlite3 {sqlite3.sqlite_version})",
+    ]
+
+    if _DEBUG_PATH_RE.search(path):
+        lines.append(
+            "            WARNING: path looks like a debug build; "
+            "benchmark numbers will not be representative.")
+        warnings.warn(
+            f"Benchmarking what looks like a debug build: {path}. "
+            "Use a release build (build/release/...) for representative numbers.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    return lines
+
+
 @pytest.fixture(scope="session")
 def num_elements() -> int:
     return int(os.environ.get("NUM_ELEMENTS", 3000))
@@ -51,16 +139,13 @@ def num_elements() -> int:
 
 
 @pytest.fixture(scope="session")
-def sqlite_conn() -> Iterator[sqlite3.Connection]:
+def sqlite_conn(vectorlite_path: str) -> Iterator[sqlite3.Connection]:
     """A SQLite connection with vectorlite (and any optional extensions) loaded.
 
     ``isolation_level=None`` puts sqlite3 in autocommit mode so that the
     explicit ``BEGIN TRANSACTION`` / ``COMMIT`` issued by ``_SqlBackend``
     is honoured.
     """
-    vectorlite_path = os.environ.get(
-        "VECTORLITE_PATH", vectorlite_py.vectorlite_path())
-
     conn = sqlite3.connect(":memory:", isolation_level=None)
     conn.enable_load_extension(True)
     conn.load_extension(vectorlite_path)

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -25,9 +25,23 @@ from __future__ import annotations
 import os
 import re
 import sqlite3
+import sys
 import warnings
 from pathlib import Path
 from typing import Iterator
+
+# Hard-fail before any third-party import so the user sees a clear error
+# rather than a confusing pip / NumPy ABI mismatch downstream. The
+# effective floor is currently driven by the wheel availability of the
+# pinned dependencies (notably NumPy 2.4, which has no wheels for
+# Python < 3.10).
+_REQUIRED_PYTHON = (3, 10)
+if sys.version_info < _REQUIRED_PYTHON:
+    sys.exit(
+        f"benchmark requires Python >= "
+        f"{_REQUIRED_PYTHON[0]}.{_REQUIRED_PYTHON[1]}, "
+        f"got {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}."
+    )
 
 import pytest
 import vectorlite_py

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -73,6 +73,14 @@ def _env_flag(name: str) -> bool:
 
 _DEBUG_PATH_RE = re.compile(r"(/build/dev/|/Debug/|/debug/)")
 
+# Vectorlite's metadata-filter (rowid pushdown) feature requires SQLite
+# >= 3.38. The benchmark itself does not exercise that path, but if the
+# user is going to use the same Python interpreter to run the
+# metadata-filter examples afterwards, we want them to know whether it
+# will work. This threshold is informational only - we still let the
+# benchmark run.
+_VECTORLITE_RECOMMENDED_SQLITE = (3, 38, 0)
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("vectorlite", "vectorlite benchmark options")
@@ -127,6 +135,14 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
         f"vectorlite: {path}",
         f"            ({size_str}, sqlite3 {sqlite3.sqlite_version})",
     ]
+
+    if sqlite3.sqlite_version_info < _VECTORLITE_RECOMMENDED_SQLITE:
+        recommended = ".".join(str(p) for p in _VECTORLITE_RECOMMENDED_SQLITE)
+        lines.append(
+            f"            NOTE: sqlite3 {sqlite3.sqlite_version} is below "
+            f"{recommended}; vectorlite's metadata-filter "
+            f"(rowid pushdown) feature requires sqlite3 >= {recommended}. "
+            "The benchmark itself does not use that feature.")
 
     if _DEBUG_PATH_RE.search(path):
         lines.append(

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -1,0 +1,149 @@
+"""Pytest fixtures for the vectorlite benchmark suite.
+
+Provides session-scoped, expensive resources (extension-loaded sqlite
+connection, randomly generated test data, ground-truth labels) plus
+``backend_factory`` fixtures that hand out fresh ``Backend`` instances to
+each test.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Iterator
+
+import pytest
+import vectorlite_py
+
+from benchmark import (
+    BenchmarkData,
+    DIMS,
+    DISTANCE_TYPES,
+    HnswlibBackend,
+    K,
+    MilvusLiteBackend,
+    NUM_QUERIES,
+    SqliteVecBackend,
+    SqliteVssBackend,
+    VectorliteBackend,
+    VectorliteBruteForceBackend,
+    is_supported_platform,
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "0") != "0"
+
+
+@pytest.fixture(scope="session")
+def num_elements() -> int:
+    return int(os.environ.get("NUM_ELEMENTS", 3000))
+
+
+# ---------------------------------------------------------------------------
+# SQLite connection (session-scoped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def sqlite_conn() -> Iterator[sqlite3.Connection]:
+    """A SQLite connection with vectorlite (and any optional extensions) loaded.
+
+    ``isolation_level=None`` puts sqlite3 in autocommit mode so that the
+    explicit ``BEGIN TRANSACTION`` / ``COMMIT`` issued by ``_SqlBackend``
+    is honoured.
+    """
+    vectorlite_path = os.environ.get(
+        "VECTORLITE_PATH", vectorlite_py.vectorlite_path())
+
+    conn = sqlite3.connect(":memory:", isolation_level=None)
+    conn.enable_load_extension(True)
+    conn.load_extension(vectorlite_path)
+
+    if _env_flag("BENCHMARK_VSS") and is_supported_platform():
+        # sqlite_vss is not self-contained; on Debian/Ubuntu install:
+        #   sudo apt-get install -y libgomp1 libatlas-base-dev liblapack-dev
+        import sqlite_vss
+        sqlite_vss.load(conn)
+
+    if _env_flag("BENCHMARK_SQLITE_VEC") and is_supported_platform():
+        import sqlite_vec
+        conn.load_extension(sqlite_vec.loadable_path())
+
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="session")
+def sqlite_cursor(sqlite_conn: sqlite3.Connection) -> sqlite3.Cursor:
+    return sqlite_conn.cursor()
+
+
+# ---------------------------------------------------------------------------
+# Random vectors and ground truth (session-scoped, expensive)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def benchmark_data(num_elements: int) -> BenchmarkData:
+    return BenchmarkData.generate(
+        DIMS, num_elements, NUM_QUERIES, K, DISTANCE_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# Backend factories
+# ---------------------------------------------------------------------------
+#
+# Each factory yields a freshly-constructed backend per test. The backend's
+# lifecycle (setup -> insert -> search -> teardown) is driven inside the test
+# itself so that pytest-benchmark can time the relevant phase.
+
+
+@pytest.fixture
+def vectorlite_backend(sqlite_cursor, benchmark_data) -> VectorliteBackend:
+    return VectorliteBackend(sqlite_cursor, benchmark_data)
+
+
+@pytest.fixture
+def vectorlite_bf_backend(sqlite_cursor,
+                          benchmark_data) -> VectorliteBruteForceBackend:
+    return VectorliteBruteForceBackend(sqlite_cursor, benchmark_data)
+
+
+@pytest.fixture
+def hnswlib_backend(benchmark_data) -> HnswlibBackend:
+    return HnswlibBackend(benchmark_data)
+
+
+@pytest.fixture
+def sqlite_vss_backend(sqlite_cursor, benchmark_data) -> SqliteVssBackend:
+    if not _env_flag("BENCHMARK_VSS"):
+        pytest.skip("set BENCHMARK_VSS=1 to enable sqlite_vss benchmark")
+    if not is_supported_platform():
+        pytest.skip("sqlite_vss only supported on Linux/macOS")
+    return SqliteVssBackend(sqlite_cursor, benchmark_data)
+
+
+@pytest.fixture
+def sqlite_vec_backend(sqlite_cursor, benchmark_data) -> SqliteVecBackend:
+    if not _env_flag("BENCHMARK_SQLITE_VEC"):
+        pytest.skip("set BENCHMARK_SQLITE_VEC=1 to enable sqlite_vec benchmark")
+    if not is_supported_platform():
+        pytest.skip("sqlite_vec only supported on Linux/macOS")
+    return SqliteVecBackend(sqlite_cursor, benchmark_data)
+
+
+@pytest.fixture
+def milvus_lite_backend(benchmark_data) -> MilvusLiteBackend:
+    if not _env_flag("BENCHMARK_MILVUS_LITE"):
+        pytest.skip("set BENCHMARK_MILVUS_LITE=1 to enable milvus-lite benchmark")
+    if not is_supported_platform():
+        pytest.skip("milvus-lite only supported on Linux/macOS")
+    return MilvusLiteBackend(benchmark_data)

--- a/benchmark/plot.py
+++ b/benchmark/plot.py
@@ -1,12 +1,191 @@
-from typing import List
+"""Render PNG plots from pytest-benchmark JSON output.
+
+Reads a JSON file produced by ``pytest --benchmark-json=<path>`` and emits
+two figures matching the layout the original ``benchmark.py`` produced:
+
+    vector_insertion_<N>_vectors.png   per-vector insert time vs. dim,
+                                       grouped by (product, distance_type)
+    vector_query_<N>_vectors.png       per-query search time vs. dim,
+                                       grouped by (product, distance_type, ef_search)
+
+Recall, when present, is included in a CSV companion file alongside each
+PNG so it isn't lost.
+
+Usage::
+
+    python benchmark/plot.py bench.json
+    python benchmark/plot.py bench.json --output-dir ./figures
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
 import matplotlib.pyplot as plt
 import pandas as pd
-plt.close("all")
 
-# plot assumes dim is the first column
-def plot(name: str, columns: List[str], data: List[List[float]]):
-    df = pd.DataFrame(data, columns=columns)
-    df.plot.bar(x=columns[0], xlabel='vector dimension', ylabel='time(us)/vector', title=f'{name} (lower is better)', rot=0, figsize=(10, 10))
-    plt.savefig(f"{name}.png")
 
-# plot("test", ["dim", "b", "c", "d"], [[1,2,3,4], [5,6,7,8], [128, 3, 4, 5]])
+def _load(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        doc = json.load(f)
+    return doc["benchmarks"]
+
+
+def _per_vector_us(stats_seconds: float, num_elements: int) -> float:
+    """Median insert wall time divided by num_elements, in microseconds."""
+    return (stats_seconds / num_elements) * 1_000_000
+
+
+def _per_query_us(stats_seconds: float, num_queries: int) -> float:
+    """Median search wall time divided by num_queries, in microseconds."""
+    return (stats_seconds / num_queries) * 1_000_000
+
+
+def _plot(name: str, df: pd.DataFrame, ylabel: str, out_dir: Path) -> Path:
+    """Bar chart matching the original plot.py layout."""
+    fig = df.plot.bar(
+        x="dim",
+        xlabel="vector dimension",
+        ylabel=ylabel,
+        title=f"{name} (lower is better)",
+        rot=0,
+        figsize=(10, 10),
+    ).get_figure()
+    out_path = out_dir / f"{name}.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+def _build_insertion(records: List[dict]) -> Tuple[pd.DataFrame, int]:
+    """Build a wide-format DataFrame of per-vector insert times.
+
+    Rows = dim, columns = plot_label, values = microseconds per vector.
+    Returns the DataFrame and the (assumed shared) num_elements.
+    """
+    if not records:
+        return pd.DataFrame(), 0
+
+    # dim -> {plot_label -> us}
+    table: Dict[int, Dict[str, float]] = defaultdict(dict)
+    num_elements = records[0]["extra_info"]["num_elements"]
+    for r in records:
+        info = r["extra_info"]
+        median_seconds = r["stats"]["median"]
+        table[info["dim"]][info["plot_label"]] = _per_vector_us(
+            median_seconds, info["num_elements"])
+
+    dims = sorted(table)
+    columns = sorted({label for row in table.values() for label in row})
+    df = pd.DataFrame(
+        [[d] + [table[d].get(c, float("nan")) for c in columns] for d in dims],
+        columns=["dim"] + columns,
+    )
+    return df, num_elements
+
+
+def _build_query(records: List[dict]) -> Tuple[pd.DataFrame, int]:
+    """Per-query search time table; honours include_in_query_plot."""
+    if not records:
+        return pd.DataFrame(), 0
+
+    table: Dict[int, Dict[str, float]] = defaultdict(dict)
+    num_elements = 0
+    for r in records:
+        info = r["extra_info"]
+        if not info.get("include_in_query_plot", True):
+            continue
+        median_seconds = r["stats"]["median"]
+        table[info["dim"]][info["plot_label"]] = _per_query_us(
+            median_seconds, info["num_queries"])
+        # num_elements isn't carried on query records by default; pull from
+        # any companion insertion record via the surrounding benchmark file.
+        # (The caller passes it in via _build_with_num_elements.)
+
+    dims = sorted(table)
+    columns = sorted({label for row in table.values() for label in row})
+    df = pd.DataFrame(
+        [[d] + [table[d].get(c, float("nan")) for c in columns] for d in dims],
+        columns=["dim"] + columns,
+    )
+    return df, num_elements
+
+
+def _write_recall_csv(records: List[dict], path: Path) -> None:
+    rows = [
+        (r["extra_info"].get("product"),
+         r["extra_info"].get("distance_type"),
+         r["extra_info"].get("dim"),
+         r["extra_info"].get("ef_search"),
+         r["extra_info"].get("recall"))
+        for r in records if "recall" in r["extra_info"]
+    ]
+    if not rows:
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(("product", "distance_type", "dim", "ef_search", "recall"))
+        w.writerows(rows)
+
+
+def _infer_num_elements(records: List[dict]) -> int:
+    for r in records:
+        n = r["extra_info"].get("num_elements")
+        if n:
+            return n
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("json_path", type=Path,
+                        help="Path to pytest-benchmark JSON output")
+    parser.add_argument("--output-dir", type=Path, default=Path("."),
+                        help="Directory to write PNG/CSV files into "
+                             "(default: current directory)")
+    args = parser.parse_args(argv)
+
+    records = _load(args.json_path)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    insertion = [r for r in records
+                 if r["extra_info"].get("plot_kind") == "insertion"]
+    query = [r for r in records
+             if r["extra_info"].get("plot_kind") == "query"]
+
+    # num_elements is always recorded on insertion records; query records
+    # share the same dataset so we look it up from the insertion side.
+    num_elements = _infer_num_elements(insertion) or _infer_num_elements(query)
+    if num_elements == 0:
+        print("error: could not infer num_elements from any benchmark record",
+              file=sys.stderr)
+        return 1
+
+    if insertion:
+        df, _ = _build_insertion(insertion)
+        out = _plot(
+            f"vector_insertion_{num_elements}_vectors",
+            df, "time(us)/vector", args.output_dir)
+        print(f"wrote {out}")
+
+    if query:
+        df, _ = _build_query(query)
+        out = _plot(
+            f"vector_query_{num_elements}_vectors",
+            df, "time(us)/query", args.output_dir)
+        print(f"wrote {out}")
+        _write_recall_csv(
+            query, args.output_dir / f"vector_query_{num_elements}_vectors_recall.csv")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/benchmark/requirements-extra.txt
+++ b/benchmark/requirements-extra.txt
@@ -1,2 +1,2 @@
-sqlite_vec>=0.1.0
-sqlite_vss>=0.1.0
+sqlite_vec>=0.1.9
+sqlite_vss>=0.1.2

--- a/benchmark/requirements-extra.txt
+++ b/benchmark/requirements-extra.txt
@@ -1,2 +1,4 @@
 sqlite_vec>=0.1.9
 sqlite_vss>=0.1.2
+libsql-experimental>=0.0.55; sys_platform != "win32"
+sqliteai-vector

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,8 +1,11 @@
-vectorlite_py
-numpy>=1.22
-apsw>=3.45
-rich>=13.7
+vectorlite_py>=0.2.0
+numpy>=2.4.4
+apsw>=3.53.0.0
+rich>=15.0.0
 hnswlib>=0.8
-matplotlib
-pandas
-pymilvus
+matplotlib>=3.10.9
+pandas>=3.0.2
+# milvus_lite extra is required for the optional MilvusLite backend
+# (BENCHMARK_MILVUS_LITE=1). Linux/macOS only.
+pymilvus[milvus_lite]>=2.6.12; sys_platform != "win32"
+pymilvus>=2.6.12; sys_platform == "win32"

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,9 +1,10 @@
 vectorlite_py>=0.2.0
 numpy>=2.4.4
-rich>=15.0.0
 hnswlib>=0.8
 matplotlib>=3.10.9
 pandas>=3.0.2
+pytest>=8.0
+pytest-benchmark>=5.2.3
 # milvus_lite extra is required for the optional MilvusLite backend
 # (BENCHMARK_MILVUS_LITE=1). Linux/macOS only.
 pymilvus[milvus_lite]>=2.6.12; sys_platform != "win32"

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,6 +1,5 @@
 vectorlite_py>=0.2.0
 numpy>=2.4.4
-apsw>=3.53.0.0
 rich>=15.0.0
 hnswlib>=0.8
 matplotlib>=3.10.9

--- a/benchmark/test_benchmark.py
+++ b/benchmark/test_benchmark.py
@@ -1,0 +1,257 @@
+"""pytest-benchmark suite for vectorlite and comparable vector backends.
+
+Run::
+
+    # Default backends only (vectorlite, hnswlib, vectorlite brute force):
+    pytest benchmark/test_benchmark.py --benchmark-json=bench.json
+
+    # All backends:
+    BENCHMARK_VSS=1 BENCHMARK_SQLITE_VEC=1 BENCHMARK_MILVUS_LITE=1 \\
+        pytest benchmark/test_benchmark.py --benchmark-json=bench.json
+
+    # Render PNG plots from the JSON output:
+    python benchmark/plot.py bench.json
+
+Each parametrised test cell contributes one benchmark to the JSON output.
+The benchmark's ``extra_info`` dict carries the metadata that ``plot.py``
+needs to group results into the existing two figures
+(insertion-time-per-vector and query-time-per-query, both vs. dim):
+
+    extra_info = {
+        "plot_kind":               "insertion" | "query",
+        "plot_label":              <legend label>,
+        "product":                 backend.name,
+        "distance_type":           "l2" | "cosine",
+        "dim":                     int,
+        "ef_search":               int | None,            # query only
+        "recall":                  float,                 # query only
+        "include_in_query_plot":   bool,                  # query only
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from benchmark import (
+    Backend,
+    BenchmarkData,
+    DIMS,
+    DISTANCE_TYPES,
+    EF_SEARCH_VALUES,
+    HNSW_PARAMS,
+    K,
+    NUM_QUERIES,
+    compute_recall,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _skip_if_unsupported(backend: Backend, distance_type: str) -> None:
+    if distance_type not in backend.supported_distances:
+        pytest.skip(f"{backend.name} does not support {distance_type}")
+
+
+def _run_insert(benchmark, backend: Backend, data: BenchmarkData,
+                distance_type: str, dim: int,
+                ef_construction: Optional[int], M: Optional[int]) -> None:
+    """Time one bulk insert into a fresh index.
+
+    Uses ``pedantic`` with a per-round setup that recreates the underlying
+    storage so each round measures the same cold-insert cost. The wall-clock
+    time of teardown/setup itself is not measured.
+    """
+    _skip_if_unsupported(backend, distance_type)
+
+    def setup() -> tuple:
+        backend.teardown()  # safe to call before first setup
+        backend.setup(distance_type, dim, ef_construction, M)
+        return (), {}
+
+    try:
+        benchmark.pedantic(
+            lambda: backend.do_insert(distance_type, dim),
+            setup=setup,
+            rounds=3,
+            iterations=1,
+            warmup_rounds=1,
+        )
+    finally:
+        backend.teardown()
+
+    benchmark.extra_info.update({
+        "plot_kind": "insertion",
+        "plot_label": backend.insertion_label(distance_type),
+        "product": backend.name,
+        "distance_type": distance_type,
+        "dim": dim,
+        "num_elements": data.num_elements,
+    })
+
+
+def _run_search(benchmark, backend: Backend, data: BenchmarkData,
+                distance_type: str, dim: int,
+                ef_construction: Optional[int], M: Optional[int],
+                ef_search: Optional[int]) -> None:
+    """Time one batch of NUM_QUERIES kNN searches against a built index.
+
+    pytest-benchmark auto-calibrates rounds and warm-up. We build the index
+    once outside the timer.
+    """
+    _skip_if_unsupported(backend, distance_type)
+    if ef_search is not None and not backend.supports_ef_search:
+        pytest.skip(f"{backend.name} does not parametrise on ef_search")
+
+    backend.setup(distance_type, dim, ef_construction, M)
+    try:
+        backend.do_insert(distance_type, dim)
+        results = benchmark(
+            backend.do_search, distance_type, dim, ef_search)
+        recall = compute_recall(
+            results, data.correct_labels[distance_type][dim], K)
+    finally:
+        backend.teardown()
+
+    benchmark.extra_info.update({
+        "plot_kind": "query",
+        "plot_label": backend.query_label(distance_type, ef_search),
+        "product": backend.name,
+        "distance_type": distance_type,
+        "dim": dim,
+        "ef_search": ef_search,
+        "recall": recall,
+        "include_in_query_plot": backend.include_in_query_plot,
+        "num_queries": NUM_QUERIES,
+    })
+
+
+# Common parametrisation marks
+_ec, _M = HNSW_PARAMS[0]
+_param_dim = pytest.mark.parametrize("dim", DIMS)
+_param_distance = pytest.mark.parametrize("distance_type", DISTANCE_TYPES)
+_param_distance_l2 = pytest.mark.parametrize("distance_type", ["l2"])
+_param_ef = pytest.mark.parametrize("ef_search", EF_SEARCH_VALUES)
+
+
+# ---------------------------------------------------------------------------
+# vectorlite (HNSW virtual table)
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance
+def test_insert_vectorlite(benchmark, vectorlite_backend, benchmark_data,
+                           distance_type, dim):
+    _run_insert(benchmark, vectorlite_backend, benchmark_data,
+                distance_type, dim, _ec, _M)
+
+
+@_param_ef
+@_param_dim
+@_param_distance
+def test_search_vectorlite(benchmark, vectorlite_backend, benchmark_data,
+                           distance_type, dim, ef_search):
+    _run_search(benchmark, vectorlite_backend, benchmark_data,
+                distance_type, dim, _ec, _M, ef_search)
+
+
+# ---------------------------------------------------------------------------
+# hnswlib (in-memory baseline)
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance
+def test_insert_hnswlib(benchmark, hnswlib_backend, benchmark_data,
+                        distance_type, dim):
+    _run_insert(benchmark, hnswlib_backend, benchmark_data,
+                distance_type, dim, _ec, _M)
+
+
+@_param_ef
+@_param_dim
+@_param_distance
+def test_search_hnswlib(benchmark, hnswlib_backend, benchmark_data,
+                        distance_type, dim, ef_search):
+    _run_search(benchmark, hnswlib_backend, benchmark_data,
+                distance_type, dim, _ec, _M, ef_search)
+
+
+# ---------------------------------------------------------------------------
+# vectorlite brute force (plain SQL table + vector_distance ORDER BY)
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance_l2
+def test_insert_vectorlite_brute_force(benchmark, vectorlite_bf_backend,
+                                       benchmark_data, distance_type, dim):
+    _run_insert(benchmark, vectorlite_bf_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance_l2
+def test_search_vectorlite_brute_force(benchmark, vectorlite_bf_backend,
+                                       benchmark_data, distance_type, dim):
+    _run_search(benchmark, vectorlite_bf_backend, benchmark_data,
+                distance_type, dim, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Optional backends - skipped unless the matching env var is set
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance_l2
+def test_insert_sqlite_vss(benchmark, sqlite_vss_backend, benchmark_data,
+                           distance_type, dim):
+    _run_insert(benchmark, sqlite_vss_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance_l2
+def test_search_sqlite_vss(benchmark, sqlite_vss_backend, benchmark_data,
+                           distance_type, dim):
+    _run_search(benchmark, sqlite_vss_backend, benchmark_data,
+                distance_type, dim, None, None, None)
+
+
+@_param_dim
+@_param_distance_l2
+def test_insert_sqlite_vec(benchmark, sqlite_vec_backend, benchmark_data,
+                           distance_type, dim):
+    _run_insert(benchmark, sqlite_vec_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance_l2
+def test_search_sqlite_vec(benchmark, sqlite_vec_backend, benchmark_data,
+                           distance_type, dim):
+    _run_search(benchmark, sqlite_vec_backend, benchmark_data,
+                distance_type, dim, None, None, None)
+
+
+@_param_dim
+@_param_distance
+def test_insert_milvus_lite(benchmark, milvus_lite_backend, benchmark_data,
+                            distance_type, dim):
+    _run_insert(benchmark, milvus_lite_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance
+def test_search_milvus_lite(benchmark, milvus_lite_backend, benchmark_data,
+                            distance_type, dim):
+    _run_search(benchmark, milvus_lite_backend, benchmark_data,
+                distance_type, dim, None, None, None)

--- a/benchmark/test_benchmark.py
+++ b/benchmark/test_benchmark.py
@@ -255,3 +255,45 @@ def test_search_milvus_lite(benchmark, milvus_lite_backend, benchmark_data,
                             distance_type, dim):
     _run_search(benchmark, milvus_lite_backend, benchmark_data,
                 distance_type, dim, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# libSQL (DiskANN vector index)
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance
+def test_insert_libsql(benchmark, libsql_backend, benchmark_data,
+                       distance_type, dim):
+    _run_insert(benchmark, libsql_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance
+def test_search_libsql(benchmark, libsql_backend, benchmark_data,
+                       distance_type, dim):
+    _run_search(benchmark, libsql_backend, benchmark_data,
+                distance_type, dim, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# sqlite-vector (SIMD full scan)
+# ---------------------------------------------------------------------------
+
+
+@_param_dim
+@_param_distance
+def test_insert_sqlite_vector(benchmark, sqlite_vector_backend, benchmark_data,
+                              distance_type, dim):
+    _run_insert(benchmark, sqlite_vector_backend, benchmark_data,
+                distance_type, dim, None, None)
+
+
+@_param_dim
+@_param_distance
+def test_search_sqlite_vector(benchmark, sqlite_vector_backend, benchmark_data,
+                              distance_type, dim):
+    _run_search(benchmark, sqlite_vector_backend, benchmark_data,
+                distance_type, dim, None, None, None)


### PR DESCRIPTION
## Summary

Overhauls the benchmark suite to use `pytest-benchmark`, drops the `apsw` dependency in favour of stdlib `sqlite3`, and adds new comparison backends.

### Changes

**Core refactoring:**
- Drop `apsw`, use stdlib `sqlite3` with `isolation_level=None` (autocommit)
- Switch from hand-rolled timing to `pytest-benchmark` (pedantic mode for inserts, auto-calibrated for queries)
- Make local-build benchmarking ergonomic (`--vectorlite-path` flag, `VECTORLITE_PATH` env var, debug build warnings)
- Enforce Python >= 3.10 floor (driven by NumPy 2.4 wheel availability)
- Surface SQLite version in session header with distribution guidance

**Bug fixes:**
- Wrap `_insert_rows` in try/except to `ROLLBACK` on failure, preventing cascading transaction errors
- Pass `limit=K` to `MilvusClient.search()` so recall is correct when K differs from default

**New backends:**
- **libSQL** (`BENCHMARK_LIBSQL=1`) — Turso/libSQL with built-in DiskANN vector index via `libsql-experimental`
- **sqlite-vector** (`BENCHMARK_SQLITE_VECTOR=1`) — sqliteai SIMD-accelerated full scan via `sqliteai-vector`

**Documentation:**
- Comprehensive `benchmark/README.md` covering quick start, configuration, CI diffing, SQLite version guidance

### Benchmark results (3000 vectors, search median ms / 100 queries)

| dim | vectorlite (ef=10) | hnswlib (ef=10) | sqlite-vec | sqlite-vss | sqlite-vector |
|-----|---|---|---|---|---|
| 128 | **1.1** | 2.0 | 13.7 | 23.5 | 23.6 |
| 512 | **2.7** | 11.9 | 48.1 | 76.3 | 61.6 |
| 1536 | **8.9** | 46.3 | 133.7 | 226.1 | 184.9 |
| 3000 | **23.8** | 97.0 | 243.3 | 441.8 | 310.9 |

> **Note:** libSQL and milvus-lite backends skip on Python 3.14 due to upstream package incompatibilities (pyo3 segfault and missing wheels respectively). Both work on Python 3.12/3.13.