### PR TITLE
Add vcpkg binary caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-binary-cache
+      CIBW_ENVIRONMENT_LINUX: "VCPKG_DEFAULT_BINARY_CACHE=/project/vcpkg-binary-cache"
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14, macos-15-intel]
@@ -46,7 +49,19 @@ jobs:
 
       - uses: benjlevesque/short-sha@v3.0
         id: short_sha
-    
+
+      - name: Create vcpkg binary cache directory
+        shell: bash
+        run: mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
+
+      - name: Cache vcpkg binary packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg-binary-cache
+          key: vcpkg-${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os }}-
+
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

Adds vcpkg binary caching to the `build_wheels` CI job so dependency builds (abseil, hnswlib, highway, rapidjson, re2, gtest, …) are reused across runs instead of being rebuilt from scratch every time.

This change already existed as commit `c6931e4` on the `storage` branch but was never merged into `main`. This PR cherry-picks just that commit onto `main`.

### What it does
- Sets `VCPKG_DEFAULT_BINARY_CACHE` (and `CIBW_ENVIRONMENT_LINUX` so the cache dir is visible inside the cibuildwheel container).
- Restores/saves the cache via `actions/cache@v4`, keyed per-OS on the hash of `vcpkg.json`, with an OS-prefixed `restore-keys` fallback.

### Why
CI currently bootstraps vcpkg and rebuilds all dependencies on every PR across 4 OSes, which dominates build time. Binary caching cuts that substantially on cache hits.

## Test Plan
- [ ] First CI run populates the cache (cold).
- [ ] Subsequent runs restore from cache and skip dependency rebuilds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>